### PR TITLE
Centralise python resource to AppData/Roaming/BHoM

### DIFF
--- a/Python_Engine/Compute/CopyEmbeddedResourceToFile.cs
+++ b/Python_Engine/Compute/CopyEmbeddedResourceToFile.cs
@@ -33,13 +33,14 @@ namespace BH.Engine.Python
         /**** Public Methods                            ****/
         /***************************************************/
 
-        public static void CopyEmbeddedResourceToFile(Assembly assembly, string resourceName, string filePath, bool force = false)
+        public static void CopyEmbeddedResourceToFile(string resourceName, string targetPath, bool force = false)
         {
-            if (force || !File.Exists(filePath))
+            if (force || !File.Exists(targetPath)) 
             {
+                Assembly assembly = typeof(Compute).Assembly;
                 var key = assembly.GetManifestResourceNames().FirstOrDefault(x => x.Contains(resourceName));
                 using (Stream stream = assembly.GetManifestResourceStream(key))
-                using (var file = new FileStream(filePath, FileMode.Create))
+                using (var file = new FileStream(targetPath, FileMode.Create))
                 {
                     if (stream == null)
                         throw new ArgumentException($"Resource name '{resourceName}' not found!");

--- a/Python_Engine/Compute/Install.cs
+++ b/Python_Engine/Compute/Install.cs
@@ -65,10 +65,17 @@ namespace BH.Engine.Python
                     // allow pip on embedded python installation by unflagging python as embedded
                     // see https://github.com/pypa/pip/issues/4207#issuecomment-281236055
                     File.Delete(Path.Combine(Query.EmbeddedPythonHome(), PYTHON_VERSION + "._pth"));
-                    // Clean up
-                    File.Delete(targetPath);
+
                 }
-                catch { }
+                catch
+                {
+                }
+                finally
+                {
+                    // Clean up
+                    if (File.Exists(targetPath))
+                        File.Delete(targetPath);
+                }
             });
         }
 

--- a/Python_Engine/Compute/Install.cs
+++ b/Python_Engine/Compute/Install.cs
@@ -47,6 +47,9 @@ namespace BH.Engine.Python
             if (!force && Query.IsInstalled()) // python seems installed, so exit
                 return;
 
+            if (!Directory.Exists(Query.EmbeddedPythonHome()))
+                Directory.CreateDirectory(Query.EmbeddedPythonHome());
+
             await Task.Run(() =>
             {
                 string resourceName = typeof(Compute).Assembly.GetManifestResourceNames().FirstOrDefault(x => x.Contains(EMBEDDED_PYTHON));

--- a/Python_Engine/Compute/Install.cs
+++ b/Python_Engine/Compute/Install.cs
@@ -49,18 +49,24 @@ namespace BH.Engine.Python
 
             await Task.Run(() =>
             {
-                var assembly = typeof(Compute).Assembly;
-                var appdata = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
-                var zip = Path.Combine(appdata, $"{EMBEDDED_PYTHON}.zip");
-                var resource_name = EMBEDDED_PYTHON;
-                CopyEmbeddedResourceToFile(assembly, resource_name, zip, force);
+                string resourceName = typeof(Compute).Assembly.GetManifestResourceNames().FirstOrDefault(x => x.Contains(EMBEDDED_PYTHON));
+                if (resourceName == null)
+                    throw new FileNotFoundException($"No embedded python zip resource found for {resourceName}");
+
+                // Copy the python embedded zip file to AppData/Roaming/BHoM/
+                string targetFolder = Query.EmbeddedPythonHome();
+                string targetPath = targetFolder + ".zip";
+                CopyEmbeddedResourceToFile(resourceName, targetPath, force);
+
                 try
                 {
-                    ZipFile.ExtractToDirectory(zip, zip.Replace(".zip", ""));
+                    ZipFile.ExtractToDirectory(targetPath, targetPath.Replace(".zip", ""));
 
                     // allow pip on embedded python installation by unflagging python as embedded
                     // see https://github.com/pypa/pip/issues/4207#issuecomment-281236055
                     File.Delete(Path.Combine(Query.EmbeddedPythonHome(), PYTHON_VERSION + "._pth"));
+                    // Clean up
+                    File.Delete(targetPath);
                 }
                 catch { }
             });

--- a/Python_PostBuild/App.config
+++ b/Python_PostBuild/App.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+    <startup> 
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.2" />
+    </startup>
+</configuration>

--- a/Python_PostBuild/Program.cs
+++ b/Python_PostBuild/Program.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using BH.Engine.Python;
+
+namespace BH.PostBuild.Python
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            // Install python
+            Compute.Install().Wait();
+
+            // Check the installation was successful 
+            if (!Query.IsInstalled())
+                throw new SystemException("Could not install Python");
+
+            // Install pip
+            Compute.InstallPip();
+
+            // Check the pip installation was successful 
+            if (!Query.IsPipInstalled())
+                throw new SystemException("Could not install pip");
+
+            // Install most commonly used ml packages
+
+            if (args.Length <= 0 || !bool.Parse(args[0]))
+                return;
+
+            // Pillow
+            Compute.PipInstall("pillow");
+
+            // numpy
+            Compute.PipInstall("numpy");
+
+            // tensorflow
+            Compute.PipInstall("tensorflow", "2.0");
+
+            // pytorch
+            Compute.PipInstall("torch===1.4.0 torchvision===0.5.0 -f https://download.pytorch.org/whl/torch_stable.html");
+
+            //scikit learn
+        }
+    }
+}

--- a/Python_PostBuild/Program.cs
+++ b/Python_PostBuild/Program.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using BH.Engine.Python;
 
 namespace BH.PostBuild.Python
@@ -7,8 +8,13 @@ namespace BH.PostBuild.Python
     {
         static void Main(string[] args)
         {
+            // Parsing arguments
+            bool force = false;
+            if (args.Contains("--force"))
+                force = true;
+
             // Install python
-            Compute.Install().Wait();
+            Compute.Install(force).Wait();
 
             // Check the installation was successful 
             if (!Query.IsInstalled())
@@ -22,23 +28,17 @@ namespace BH.PostBuild.Python
                 throw new SystemException("Could not install pip");
 
             // Install most commonly used ml packages
+            foreach(string module in args)
+            {
+                if (module.Contains("--force"))
+                    continue;
 
-            if (args.Length <= 0 || !bool.Parse(args[0]))
-                return;
-
-            // Pillow
-            Compute.PipInstall("pillow");
-
-            // numpy
-            Compute.PipInstall("numpy");
-
-            // tensorflow
-            Compute.PipInstall("tensorflow", "2.0");
-
-            // pytorch
-            Compute.PipInstall("torch===1.4.0 torchvision===0.5.0 -f https://download.pytorch.org/whl/torch_stable.html");
-
-            //scikit learn
+                try
+                {
+                    Compute.PipInstall(module);
+                }
+                catch { }
+            }
         }
     }
 }

--- a/Python_PostBuild/Program.cs
+++ b/Python_PostBuild/Program.cs
@@ -14,6 +14,7 @@ namespace BH.PostBuild.Python
                 force = true;
 
             // Install python
+            Console.WriteLine("Installing python 3.7 embedded...");
             Compute.Install(force).Wait();
 
             // Check the installation was successful 
@@ -21,6 +22,7 @@ namespace BH.PostBuild.Python
                 throw new SystemException("Could not install Python");
 
             // Install pip
+            Console.WriteLine("Installing pip...");
             Compute.InstallPip();
 
             // Check the pip installation was successful 
@@ -35,6 +37,7 @@ namespace BH.PostBuild.Python
 
                 try
                 {
+                    Console.WriteLine($"Installing {module}");
                     Compute.PipInstall(module);
                 }
                 catch { }

--- a/Python_PostBuild/Properties/AssemblyInfo.cs
+++ b/Python_PostBuild/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Python_PostBuild")]
+[assembly: AssemblyDescription("BHoM Python PostBuild")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Python_PostBuild")]
+[assembly: AssemblyCopyright("Copyright © https://github.com/BHoM")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("830f827f-ac6f-4d27-9625-7756b65492b8")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("3.0.0.0")]
+[assembly: AssemblyFileVersion("3.1.0.0")]

--- a/Python_PostBuild/Python_PostBuild.csproj
+++ b/Python_PostBuild/Python_PostBuild.csproj
@@ -57,6 +57,7 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>$(TargetPath) false</PostBuildEvent>
+    <PostBuildEvent>rem $(TargetPath) calls the appitself to install python at compilation time
+$(TargetPath)</PostBuildEvent>
   </PropertyGroup>
 </Project>

--- a/Python_PostBuild/Python_PostBuild.csproj
+++ b/Python_PostBuild/Python_PostBuild.csproj
@@ -57,7 +57,6 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>rem $(TargetPath) calls the appitself to install python at compilation time
-$(TargetPath)</PostBuildEvent>
+    <PostBuildEvent>"$(TargetPath)"</PostBuildEvent>
   </PropertyGroup>
 </Project>

--- a/Python_PostBuild/Python_PostBuild.csproj
+++ b/Python_PostBuild/Python_PostBuild.csproj
@@ -1,0 +1,62 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{830F827F-AC6F-4D27-9625-7756B65492B8}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>Python_PostBuild</RootNamespace>
+    <AssemblyName>Python_PostBuild</AssemblyName>
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <Deterministic>true</Deterministic>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Python_Engine\Python_Engine.csproj">
+      <Project>{4a6b3805-35ee-4278-9701-cc1e0cd641f9}</Project>
+      <Name>Python_Engine</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <PropertyGroup>
+    <PostBuildEvent>$(TargetPath) false</PostBuildEvent>
+  </PropertyGroup>
+</Project>

--- a/Python_Toolkit.sln
+++ b/Python_Toolkit.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 15.0.28307.572
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Python_Engine", "Python_Engine\Python_Engine.csproj", "{4A6B3805-35EE-4278-9701-CC1E0CD641F9}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Python_PostBuild", "Python_PostBuild\Python_PostBuild.csproj", "{830F827F-AC6F-4D27-9625-7756B65492B8}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -15,6 +17,10 @@ Global
 		{4A6B3805-35EE-4278-9701-CC1E0CD641F9}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{4A6B3805-35EE-4278-9701-CC1E0CD641F9}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{4A6B3805-35EE-4278-9701-CC1E0CD641F9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{830F827F-AC6F-4D27-9625-7756B65492B8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{830F827F-AC6F-4D27-9625-7756B65492B8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{830F827F-AC6F-4D27-9625-7756B65492B8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{830F827F-AC6F-4D27-9625-7756B65492B8}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->
   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1 

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
The test is done by just compiling the application and checking the `AppData/Roaming/BHoM` directory contains a `python-3.7.3-embed-amd64` folder. Then, it can be tested in tandem with this pr https://github.com/BHoM/Keras_Toolkit/pull/14. `LoadImg` is a simple function to test.

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- Centralise the python local installation to `AppData/Roaming/BHoM`
- Add PostBuild events to install python at compile time
- Add the possibility to install modules from post build events

### Additional comments
<!-- As required -->
@FraserGreenroyd this pr does not have labels because they are not set for this repo. 
I will raise an issue for that, would it be ok to pick it up?
@MarthaVoul I added you to this pull request just to start familiarising with what is happening on the framework side. I do not expect you to pick up the review, but you can if you want. So, no pressure :)