### PR TITLE
Add ability to use the BHoM API from python

### DIFF
--- a/Python_Engine/Compute/Install.cs
+++ b/Python_Engine/Compute/Install.cs
@@ -46,7 +46,24 @@ namespace BH.Engine.Python
             string path = Environment.GetEnvironmentVariable("PATH", EnvironmentVariableTarget.User);
             if (!path.Contains(home))
                 Environment.SetEnvironmentVariable("PATH", path + ";" + home, EnvironmentVariableTarget.User);
-            //Environment.SetEnvironmentVariable("PATH", home + ";" + path, EnvironmentVariableTarget.User);
+
+            // make sure pyBHoM is imported at python startup
+            string startupCommand = "import pyBHoM";
+            string pythonStartup = Environment.GetEnvironmentVariable("PYTHONSTARTUP", EnvironmentVariableTarget.User);
+            // if no startup file is defined, write one
+            if (pythonStartup == null)
+            {
+                pythonStartup = Path.Combine(home, "startup.py");
+                Directory.CreateDirectory(home);
+                System.IO.File.WriteAllText(pythonStartup, startupCommand);
+                Environment.SetEnvironmentVariable("PYTHONSTARTUP", pythonStartup, EnvironmentVariableTarget.User);
+            }
+            // if it exists, and does not contain the pyBHoM command already, append it
+            else if (!File.ReadAllLines(pythonStartup).Contains(startupCommand))
+            {
+                using (StreamWriter file = new StreamWriter(pythonStartup, true))
+                    file.WriteLine(startupCommand);
+            }
 
             if (!force && Query.IsInstalled()) // python seems installed, so exit
                 return;

--- a/Python_Engine/Compute/Install.cs
+++ b/Python_Engine/Compute/Install.cs
@@ -45,7 +45,8 @@ namespace BH.Engine.Python
             string home = Query.EmbeddedPythonHome();
             string path = Environment.GetEnvironmentVariable("PATH", EnvironmentVariableTarget.User);
             if (!path.Contains(home))
-                Environment.SetEnvironmentVariable("PATH", home + ";" + path, EnvironmentVariableTarget.User);
+                Environment.SetEnvironmentVariable("PATH", path + ";" + home, EnvironmentVariableTarget.User);
+            //Environment.SetEnvironmentVariable("PATH", home + ";" + path, EnvironmentVariableTarget.User);
 
             if (!force && Query.IsInstalled()) // python seems installed, so exit
                 return;

--- a/Python_PostBuild/Program.cs
+++ b/Python_PostBuild/Program.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.IO;
 using System.Linq;
 using BH.Engine.Python;
 
@@ -34,6 +35,11 @@ namespace BH.PostBuild.Python
             Compute.PipInstall("jupyter");
             Compute.PipInstall("jupyterlab");
             Compute.PipInstall("pythonnet");
+
+            // install pyBHoM
+            Console.WriteLine("Installing MachineLearning_Engine...");
+            string pyBHoMPath = Path.Combine(Environment.CurrentDirectory, "..", "..", "..");
+            Compute.PipInstall($"-e {pyBHoMPath}");  // Note: The PostBuilds are run from the Python_PostBuild/bin/Debug
         }
     }
 }

--- a/Python_PostBuild/Program.cs
+++ b/Python_PostBuild/Program.cs
@@ -33,6 +33,7 @@ namespace BH.PostBuild.Python
             Console.WriteLine("Installing jupyter...");
             Compute.PipInstall("jupyter");
             Compute.PipInstall("jupyterlab");
+            Compute.PipInstall("pythonnet");
         }
     }
 }

--- a/pyBHoM/__init__.py
+++ b/pyBHoM/__init__.py
@@ -1,0 +1,46 @@
+#
+# This file is part of the Buildings and Habitats object Model (BHoM)
+# Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
+#
+# Each contributor holds copyright over their respective contributions.
+# The project versioning (Git) records all such contribution source information.
+#
+#
+# The BHoM is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3.0 of the License, or
+# (at your option) any later version.
+#
+# The BHoM is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.
+#
+
+
+import sys
+import os
+import clr
+from glob import glob
+
+bhom_home = os.path.join(os.getenv("APPDATA"), "BHoM", "Assemblies")
+sys.path.append(bhom_home)
+
+# add oM libraries
+for assembly in glob(bhom_home + "/*_oM.dll"):
+	clr.AddReference(os.path.join(bhom_home, assembly))
+
+# add Engine libraries
+for assembly in glob(bhom_home + "/*_Engine.dll"):
+	clr.AddReference(os.path.join(bhom_home, assembly))
+
+# add Engine libraries
+for assembly in glob(bhom_home + "/*_Adapter.dll"):
+	clr.AddReference(os.path.join(bhom_home, assembly))
+
+
+from System import *
+from System.Collections.Generic import *

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,33 @@
+#
+# This file is part of the Buildings and Habitats object Model (BHoM)
+# Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
+#
+# Each contributor holds copyright over their respective contributions.
+# The project versioning (Git) records all such contribution source information.
+#
+#
+# The BHoM is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3.0 of the License, or
+# (at your option) any later version.
+#
+# The BHoM is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.
+#
+
+from distutils.core import setup
+
+setup(
+    name='pyBHoM',
+    description='Python bindings of the Buildings and Habitats object Model',
+    author='Eduardo Pignatelli',
+    author_email='info@bhom.xyz',
+    license='LGPLv3',
+    packages=["pyBHoM"],
+    version="3.1.0.0",
+    )


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->


### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #15

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
You can open grasshopper, run the `Jupyter` component that opens a new jupyter notebook and use the following code.

This is an example of how to use a `BHoMAdapter` from python:
```python
import pyBHoM, BH
import os
import System

filepath = os.path.join(os.getenv("HOME"), "Desktop", "pyBHoM_test")
file_adapter = BH.Adapter.FileAdapter.FileAdapter(filepath)

objects = System.Array[System.Object]([BH.Engine.Acoustic.Create.RT60(1., 1, 10)])

pushed = file_adapter.Push(objects)

pulled = file_adapter.Pull(None)

for item in pulled:
    print(item.get_ReceiverID())
    print(item.get_SpeakerID())
    print(item.get_Value())
    print("---")
```
And you get your `BH.oM.Acoustic.RT60` object. This works with any other python object.

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->