### PR TITLE
Initial commit of changes to ProgramData

### DIFF
--- a/Python_Engine/Compute/Install.cs
+++ b/Python_Engine/Compute/Install.cs
@@ -52,7 +52,7 @@ namespace BH.Engine.Python
             string pythonStartup = Environment.GetEnvironmentVariable("PYTHONSTARTUP", EnvironmentVariableTarget.User);
 
             // if no startup file is defined, write one
-            if (pythonStartup == null)
+            if (pythonStartup == null || !Directory.Exists(home))
             {
                 pythonStartup = Path.Combine(home, "startup.py");
                 Directory.CreateDirectory(home);

--- a/Python_Engine/Compute/Install.cs
+++ b/Python_Engine/Compute/Install.cs
@@ -78,7 +78,7 @@ namespace BH.Engine.Python
                 if (resourceName == null)
                     throw new FileNotFoundException($"No embedded python zip resource found for {resourceName}");
 
-                // Copy the python embedded zip file to AppData/Roaming/BHoM/
+                // Copy the python embedded zip file to ProgramData/BHoM/
                 string targetFolder = Query.EmbeddedPythonHome();
                 string targetPath = targetFolder + ".zip";
                 CopyEmbeddedResourceToFile(resourceName, targetPath, force);

--- a/Python_Engine/Compute/Install.cs
+++ b/Python_Engine/Compute/Install.cs
@@ -50,6 +50,7 @@ namespace BH.Engine.Python
             // make sure pyBHoM is imported at python startup
             string startupCommand = "import pyBHoM";
             string pythonStartup = Environment.GetEnvironmentVariable("PYTHONSTARTUP", EnvironmentVariableTarget.User);
+            pythonStartup = null;
             // if no startup file is defined, write one
             if (pythonStartup == null)
             {

--- a/Python_Engine/Compute/Install.cs
+++ b/Python_Engine/Compute/Install.cs
@@ -50,7 +50,7 @@ namespace BH.Engine.Python
             // make sure pyBHoM is imported at python startup
             string startupCommand = "import pyBHoM";
             string pythonStartup = Environment.GetEnvironmentVariable("PYTHONSTARTUP", EnvironmentVariableTarget.User);
-            pythonStartup = null;
+
             // if no startup file is defined, write one
             if (pythonStartup == null)
             {
@@ -59,9 +59,9 @@ namespace BH.Engine.Python
                 System.IO.File.WriteAllText(pythonStartup, startupCommand);
                 Environment.SetEnvironmentVariable("PYTHONSTARTUP", pythonStartup, EnvironmentVariableTarget.User);
             }
-            // if it exists, and does not contain the pyBHoM command already, append it
             else if (!File.ReadAllLines(pythonStartup).Contains(startupCommand))
             {
+                // if it exists, and does not contain the pyBHoM command already, append it
                 using (StreamWriter file = new StreamWriter(pythonStartup, true))
                     file.WriteLine(startupCommand);
             }

--- a/Python_Engine/Compute/InstallPythonToolkit.cs
+++ b/Python_Engine/Compute/InstallPythonToolkit.cs
@@ -1,17 +1,48 @@
-﻿using System;
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2019, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
 using System.IO;
+using BH.oM.Reflection.Attributes;
+using System.ComponentModel;
 
 namespace BH.Engine.Python
 {
     public static partial class Compute
     {
-        public static bool InstallPythonToolkit(bool force = false)
+        [Description("Installs the necessary pre-requisites to use the Python Toolkit fully. This will install Python 3.7 to your system, to the C:/ProgramData/BHoM folder. This will take several minutes to complete")]
+        [Input("run", "When you are ready to install Python, set this to true. Until this is set to true, this component will not run")]
+        [Input("force", "If you have previously installed a version of Python Toolkit, you may need to force the component to run a new install. This can happen if your system loses files. This is set to false by default, which means if we can detect a previous Python install on your system we will not install Python this time. Set this to true to ignore this check")]
+        [Output("success", "True is Python Toolkit has been successfully installer, false otherwise")]
+        public static bool InstallPythonToolkit(bool run = false, bool force = false)
         {
+            if (!run)
+                return false;
+
             // Install python
             Console.WriteLine("Installing python 3.7 embedded...");
             Compute.Install(force).Wait();

--- a/Python_Engine/Compute/InstallPythonToolkit.cs
+++ b/Python_Engine/Compute/InstallPythonToolkit.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using System.IO;
+
+namespace BH.Engine.Python
+{
+    public static partial class Compute
+    {
+        public static bool InstallPythonToolkit(bool force = false)
+        {
+            // Install python
+            Console.WriteLine("Installing python 3.7 embedded...");
+            Compute.Install(force).Wait();
+
+            // Check the installation was successful 
+            if (!Query.IsInstalled())
+            {
+                BH.Engine.Reflection.Compute.RecordError("Coule not install Python");
+                return false;
+            }
+
+            // Install pip
+            Console.WriteLine("Installing pip...");
+            Compute.InstallPip();
+
+            // Check the pip installation was successful 
+            if (!Query.IsPipInstalled())
+            {
+                BH.Engine.Reflection.Compute.RecordError("Could not install pip");
+                return false;
+            }
+
+            // install project jupyter
+            Console.WriteLine("Installing jupyter...");
+            Compute.PipInstall("jupyter");
+            Compute.PipInstall("jupyterlab");
+            Compute.PipInstall("pythonnet");
+
+            return true;
+        }
+
+    }
+}

--- a/Python_Engine/Compute/InstallPythonToolkit.cs
+++ b/Python_Engine/Compute/InstallPythonToolkit.cs
@@ -85,6 +85,7 @@ namespace BH.Engine.Python
             installedPackages.Add("pythonnet");
             installedPackages.Add("matplotlib");
 
+            success = true;
             return new Output<bool, List<string>> { Item1 = success, Item2 = installedPackages };
         }
 

--- a/Python_Engine/Compute/InstallPythonToolkit.cs
+++ b/Python_Engine/Compute/InstallPythonToolkit.cs
@@ -29,6 +29,7 @@ using System.Threading.Tasks;
 using System.IO;
 using BH.oM.Reflection.Attributes;
 using System.ComponentModel;
+using BH.oM.Reflection;
 
 namespace BH.Engine.Python
 {
@@ -38,11 +39,14 @@ namespace BH.Engine.Python
             "This can take several minutes to complete")]
         [Input("run", "When you are ready to install Python, set this to true. Until this is set to true, this component will not run")]
         [Input("force", "If you have previously installed a version of Python Toolkit, you may need to force the component to run a new install. This can happen if your system loses files. This is set to false by default, which means if we can detect a previous Python install on your system we will not install Python this time. Set this to true to ignore this check")]
-        [Output("success", "True is Python Toolkit has been successfully installer, false otherwise")]
-        public static bool InstallPythonToolkit(bool run = false, bool force = false)
+        [MultiOutput(0, "success", "True is Python Toolkit has been successfully installer, false otherwise")]
+        [MultiOutput(1, "installedPackages", "A list of the Python packages which have been installed as part of this operation")]
+        public static Output<bool, List<string>> InstallPythonToolkit(bool run = false, bool force = false)
         {
+            bool success = false;
+            List<string> installedPackages = new List<string>();
             if (!run)
-                return false;
+                return new Output<bool, List<string>> { Item1 = success, Item2 = installedPackages };
 
             // Install python
             Console.WriteLine("Installing python 3.7 embedded...");
@@ -52,7 +56,7 @@ namespace BH.Engine.Python
             if (!Query.IsInstalled())
             {
                 BH.Engine.Reflection.Compute.RecordError("Coule not install Python");
-                return false;
+                return new Output<bool, List<string>> { Item1 = success, Item2 = installedPackages };
             }
 
             // Install pip
@@ -63,7 +67,7 @@ namespace BH.Engine.Python
             if (!Query.IsPipInstalled())
             {
                 BH.Engine.Reflection.Compute.RecordError("Could not install pip");
-                return false;
+                return new Output<bool, List<string>> { Item1 = success, Item2 = installedPackages };
             }
 
             // install project jupyter
@@ -75,7 +79,13 @@ namespace BH.Engine.Python
             //Install matplotlib for graphs
             Compute.PipInstall("matplotlib");
 
-            return true;
+            installedPackages.Add("Python 3.7");
+            installedPackages.Add("jupyter");
+            installedPackages.Add("jupyterlab");
+            installedPackages.Add("pythonnet");
+            installedPackages.Add("matplotlib");
+
+            return new Output<bool, List<string>> { Item1 = success, Item2 = installedPackages };
         }
 
     }

--- a/Python_Engine/Compute/InstallPythonToolkit.cs
+++ b/Python_Engine/Compute/InstallPythonToolkit.cs
@@ -72,6 +72,9 @@ namespace BH.Engine.Python
             Compute.PipInstall("jupyterlab");
             Compute.PipInstall("pythonnet");
 
+            //Install matplotlib for graphs
+            Compute.PipInstall("matplotlib");
+
             return true;
         }
 

--- a/Python_Engine/Compute/InstallPythonToolkit.cs
+++ b/Python_Engine/Compute/InstallPythonToolkit.cs
@@ -34,7 +34,8 @@ namespace BH.Engine.Python
 {
     public static partial class Compute
     {
-        [Description("Installs the necessary pre-requisites to use the Python Toolkit fully. This will install Python 3.7 to your system, to the C:/ProgramData/BHoM folder. This will take several minutes to complete")]
+        [Description("Installs the necessary pre-requisites to use the Python Toolkit fully. This will install Python 3.7 to your system, to the C:/ProgramData/BHoM folder.\n" +
+            "This can take several minutes to complete")]
         [Input("run", "When you are ready to install Python, set this to true. Until this is set to true, this component will not run")]
         [Input("force", "If you have previously installed a version of Python Toolkit, you may need to force the component to run a new install. This can happen if your system loses files. This is set to false by default, which means if we can detect a previous Python install on your system we will not install Python this time. Set this to true to ignore this check")]
         [Output("success", "True is Python Toolkit has been successfully installer, false otherwise")]

--- a/Python_Engine/Compute/Invoke.cs
+++ b/Python_Engine/Compute/Invoke.cs
@@ -65,6 +65,12 @@ namespace BH.Engine.Python
 
         public static PyObject Invoke(PyObject module, string method, IEnumerable<object> args, Dictionary<string, object> kwargs)
         {
+            if (!Query.IsInstalled())
+            {
+                BH.Engine.Reflection.Compute.RecordError("The Python Toolkit has not been successfully installed. Please run the InstallPythonToolkit component to install the necessary dependencies to invoke Python methods within BHoM");
+                return null;
+            }
+
             PyTuple pyargs = Convert.ToPyTuple(args);
             PyDict pykwargs = Convert.ToPython(kwargs);
 

--- a/Python_Engine/Compute/Invoke.cs
+++ b/Python_Engine/Compute/Invoke.cs
@@ -34,6 +34,12 @@ namespace BH.Engine.Python
 
         public static PyObject Invoke(PyObject module, string method, Dictionary<string, object> args)
         {
+            if(!Query.IsInstalled())
+            {
+                BH.Engine.Reflection.Compute.RecordError("The Python Toolkit has not been successfully installed. Please run the InstallPythonToolkit component to install the necessary dependencies to invoke Python methods within BHoM");
+                return null;
+            }
+
             PyTuple pyargs = Convert.ToPyTuple(new object[]
             {
                 args.FirstOrDefault().Value

--- a/Python_Engine/Python_Engine.csproj
+++ b/Python_Engine/Python_Engine.csproj
@@ -70,4 +70,7 @@
     <Folder Include="Resources\" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <PropertyGroup>
+    <PostBuildEvent>xcopy "$(TargetDir)$(TargetFileName)"  "C:\\ProgramData\\BHoM\\Assemblies" /Y</PostBuildEvent>
+  </PropertyGroup>
 </Project>

--- a/Python_Engine/Python_Engine.csproj
+++ b/Python_Engine/Python_Engine.csproj
@@ -36,10 +36,10 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Reflection_Engine">
-      <HintPath>..\..\..\..\..\..\..\ProgramData\BHoM\Assemblies\Reflection_Engine.dll</HintPath>
+      <HintPath>C:\ProgramData\BHoM\Assemblies\Reflection_Engine.dll</HintPath>
     </Reference>
     <Reference Include="Reflection_oM">
-      <HintPath>..\..\..\..\..\..\..\ProgramData\BHoM\Assemblies\Reflection_oM.dll</HintPath>
+      <HintPath>C:\ProgramData\BHoM\Assemblies\Reflection_oM.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/Python_Engine/Python_Engine.csproj
+++ b/Python_Engine/Python_Engine.csproj
@@ -35,6 +35,12 @@
       <HintPath>..\packages\BH.UI.Python.Runtime.3.7.4-alpha\lib\netstandard2.0\Python.Runtime.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Reflection_Engine">
+      <HintPath>..\..\..\..\..\..\..\ProgramData\BHoM\Assemblies\Reflection_Engine.dll</HintPath>
+    </Reference>
+    <Reference Include="Reflection_oM">
+      <HintPath>..\..\..\..\..\..\..\ProgramData\BHoM\Assemblies\Reflection_oM.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.IO.Compression.FileSystem" />
@@ -50,6 +56,7 @@
     <Compile Include="Compute\Init.cs" />
     <Compile Include="Compute\Install.cs" />
     <Compile Include="Compute\InstallPip.cs" />
+    <Compile Include="Compute\InstallPythonToolkit.cs" />
     <Compile Include="Compute\PipInstall.cs" />
     <Compile Include="Compute\RunCommand.cs" />
     <Compile Include="Compute\JupyterLab.cs" />

--- a/Python_Engine/Python_Engine.csproj
+++ b/Python_Engine/Python_Engine.csproj
@@ -78,7 +78,7 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>xcopy "$(TargetDir)$(TargetFileName)"  "C:\\ProgramData\\BHoM\\Assemblies\" /Y
-xcopy "$(TargetDir)Python.Runtime.dll"  "C:\\ProgramData\\BHoM\\Assemblies\" /Y</PostBuildEvent>
+    <PostBuildEvent>xcopy "$(TargetDir)$(TargetFileName)"  "C:\\ProgramData\\BHoM\\Assemblies" /Y
+xcopy "$(TargetDir)Python.Runtime.dll"  "C:\\ProgramData\\BHoM\\Assemblies" /Y</PostBuildEvent>
   </PropertyGroup>
 </Project>

--- a/Python_Engine/Python_Engine.csproj
+++ b/Python_Engine/Python_Engine.csproj
@@ -78,6 +78,7 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>xcopy "$(TargetDir)$(TargetFileName)"  "C:\\ProgramData\\BHoM\\Assemblies" /Y</PostBuildEvent>
+    <PostBuildEvent>xcopy "$(TargetDir)$(TargetFileName)"  "C:\\ProgramData\\BHoM\\Assemblies" /Y
+xcopy "$(TargetDir)Python.Runtime.dll"  "C:\\ProgramData\\BHoM\\Assemblies" /Y</PostBuildEvent>
   </PropertyGroup>
 </Project>

--- a/Python_Engine/Python_Engine.csproj
+++ b/Python_Engine/Python_Engine.csproj
@@ -78,7 +78,7 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>xcopy "$(TargetDir)$(TargetFileName)"  "C:\\ProgramData\\BHoM\\Assemblies" /Y
-xcopy "$(TargetDir)Python.Runtime.dll"  "C:\\ProgramData\\BHoM\\Assemblies" /Y</PostBuildEvent>
+    <PostBuildEvent>xcopy "$(TargetDir)$(TargetFileName)"  "C:\\ProgramData\\BHoM\\Assemblies\" /Y
+xcopy "$(TargetDir)Python.Runtime.dll"  "C:\\ProgramData\\BHoM\\Assemblies\" /Y</PostBuildEvent>
   </PropertyGroup>
 </Project>

--- a/Python_Engine/Query/EmbeddedPythonHome.cs
+++ b/Python_Engine/Query/EmbeddedPythonHome.cs
@@ -33,7 +33,8 @@ namespace BH.Engine.Python
 
         public static string EmbeddedPythonHome()
         {
-            var installDir = Path.Combine(@"C:\ProgramData", "BHoM", Compute.EMBEDDED_PYTHON);
+            var programData = Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData);
+            var installDir = Path.Combine(programData, "BHoM", Compute.EMBEDDED_PYTHON);
             return installDir;
         }
 

--- a/Python_Engine/Query/EmbeddedPythonHome.cs
+++ b/Python_Engine/Query/EmbeddedPythonHome.cs
@@ -33,7 +33,6 @@ namespace BH.Engine.Python
 
         public static string EmbeddedPythonHome()
         {
-            var appdata = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
             var installDir = Path.Combine(@"C:\ProgramData", "BHoM", Compute.EMBEDDED_PYTHON);
             return installDir;
         }

--- a/Python_Engine/Query/EmbeddedPythonHome.cs
+++ b/Python_Engine/Query/EmbeddedPythonHome.cs
@@ -34,7 +34,7 @@ namespace BH.Engine.Python
         public static string EmbeddedPythonHome()
         {
             var appdata = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
-            var installDir = Path.Combine(appdata, "BHoM", Compute.EMBEDDED_PYTHON);
+            var installDir = Path.Combine(@"C:\ProgramData", "BHoM", Compute.EMBEDDED_PYTHON);
             return installDir;
         }
 

--- a/Python_PostBuild/Program.cs
+++ b/Python_PostBuild/Program.cs
@@ -14,32 +14,7 @@ namespace BH.PostBuild.Python
             if (args.Contains("--force"))
                 force = true;
 
-            // Install python
-            Console.WriteLine("Installing python 3.7 embedded...");
-            Compute.Install(force).Wait();
-
-            // Check the installation was successful 
-            if (!Query.IsInstalled())
-                throw new SystemException("Could not install Python");
-
-            // Install pip
-            Console.WriteLine("Installing pip...");
-            Compute.InstallPip();
-
-            // Check the pip installation was successful 
-            if (!Query.IsPipInstalled())
-                throw new SystemException("Could not install pip");
-
-            // install project jupyter
-            Console.WriteLine("Installing jupyter...");
-            Compute.PipInstall("jupyter");
-            Compute.PipInstall("jupyterlab");
-            Compute.PipInstall("pythonnet");
-
-            // install pyBHoM
-            Console.WriteLine("Installing MachineLearning_Engine...");
-            string pyBHoMPath = Path.Combine(Environment.CurrentDirectory, "..", "..", "..");
-            Compute.PipInstall($"-e {pyBHoMPath}");  // Note: The PostBuilds are run from the Python_PostBuild/bin/Debug
+            
         }
     }
 }

--- a/Python_PostBuild/Program.cs
+++ b/Python_PostBuild/Program.cs
@@ -14,32 +14,7 @@ namespace BH.PostBuild.Python
             if (args.Contains("--force"))
                 force = true;
 
-            // Install python	
-            Console.WriteLine("Installing python 3.7 embedded...");
-            Compute.Install(force).Wait();
-
-            // Check the installation was successful 	
-            if (!Query.IsInstalled())
-                throw new SystemException("Could not install Python");
-
-            // Install pip	
-            Console.WriteLine("Installing pip...");
-            Compute.InstallPip();
-
-            // Check the pip installation was successful 	
-            if (!Query.IsPipInstalled())
-                throw new SystemException("Could not install pip");
-
-            // install project jupyter	
-            Console.WriteLine("Installing jupyter...");
-            Compute.PipInstall("jupyter");
-            Compute.PipInstall("jupyterlab");
-            Compute.PipInstall("pythonnet");
-
-            // install pyBHoM	
-            Console.WriteLine("Installing MachineLearning_Engine...");
-            string pyBHoMPath = Path.Combine(Environment.CurrentDirectory, "..", "..", "..");
-            Compute.PipInstall($"-e {pyBHoMPath}");  // Note: The PostBuilds are run from the Python_PostBuild/bin/Debug
+            Compute.InstallPythonToolkit(true, force);
         }
     }
 }

--- a/Python_PostBuild/Program.cs
+++ b/Python_PostBuild/Program.cs
@@ -14,7 +14,32 @@ namespace BH.PostBuild.Python
             if (args.Contains("--force"))
                 force = true;
 
-            
+            // Install python	
+            Console.WriteLine("Installing python 3.7 embedded...");
+            Compute.Install(force).Wait();
+
+            // Check the installation was successful 	
+            if (!Query.IsInstalled())
+                throw new SystemException("Could not install Python");
+
+            // Install pip	
+            Console.WriteLine("Installing pip...");
+            Compute.InstallPip();
+
+            // Check the pip installation was successful 	
+            if (!Query.IsPipInstalled())
+                throw new SystemException("Could not install pip");
+
+            // install project jupyter	
+            Console.WriteLine("Installing jupyter...");
+            Compute.PipInstall("jupyter");
+            Compute.PipInstall("jupyterlab");
+            Compute.PipInstall("pythonnet");
+
+            // install pyBHoM	
+            Console.WriteLine("Installing MachineLearning_Engine...");
+            string pyBHoMPath = Path.Combine(Environment.CurrentDirectory, "..", "..", "..");
+            Compute.PipInstall($"-e {pyBHoMPath}");  // Note: The PostBuilds are run from the Python_PostBuild/bin/Debug
         }
     }
 }

--- a/Python_Toolkit.sln
+++ b/Python_Toolkit.sln
@@ -1,11 +1,9 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.28307.572
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.30114.105
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Python_Engine", "Python_Engine\Python_Engine.csproj", "{4A6B3805-35EE-4278-9701-CC1E0CD641F9}"
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Python_PostBuild", "Python_PostBuild\Python_PostBuild.csproj", "{830F827F-AC6F-4D27-9625-7756B65492B8}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -17,10 +15,6 @@ Global
 		{4A6B3805-35EE-4278-9701-CC1E0CD641F9}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{4A6B3805-35EE-4278-9701-CC1E0CD641F9}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{4A6B3805-35EE-4278-9701-CC1E0CD641F9}.Release|Any CPU.Build.0 = Release|Any CPU
-		{830F827F-AC6F-4D27-9625-7756B65492B8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{830F827F-AC6F-4D27-9625-7756B65492B8}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{830F827F-AC6F-4D27-9625-7756B65492B8}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{830F827F-AC6F-4D27-9625-7756B65492B8}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
### Issues addressed by this PR
Fixes #5 


### Test files
[Very basic file](https://burohappold.sharepoint.com/:u:/r/sites/BHoM/02_Current/12_Scripts/01_Test%20Scripts/Python_Toolkit/InstallTesting.gh?csf=1&web=1&e=G01pIf)


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
This updates the toolkit for using ProgramData, and removing PostBuild to allow install via Grasshopper/Dynamo/Excel.

As you can see from the file, this should allow Python Toolkit to install correctly from the UI side rather than relying on the post build. I have removed the postbuild from the SLN file but kept it within the repo for now until we're happy.

Things to test:
 - Installing and running existing Python Toolkit scripts (@epignatelli is probably best placed for that but view other PRs for help)
 - Installing Python and then deleting the folder from `C:\ProgramData\BHoM` and force installing - folder should reappear

Currently no user feedback is given, this took me 1.7 minutes on my machine to run the component, but we may want to look at doing this for the UX. I have put a description saying this may take a few minutes but that might not be enough. Though it is a one-time cost of course so maybe good wiki and docs will suffice? Thoughts?