### PR TITLE
Fix hanging tasks

### DIFF
--- a/Python_Engine/Compute/InstallPythonToolkit.cs
+++ b/Python_Engine/Compute/InstallPythonToolkit.cs
@@ -50,7 +50,7 @@ namespace BH.Engine.Python
 
             // Install python
             Console.WriteLine("Installing python 3.7 embedded...");
-            Compute.Install(force).Wait();
+            Compute.Install(force);
 
             // Check the installation was successful 
             if (!Query.IsInstalled())

--- a/Python_Engine/Compute/RunCommand.cs
+++ b/Python_Engine/Compute/RunCommand.cs
@@ -42,7 +42,7 @@ namespace BH.Engine.Python
 
             startInfo.FileName = "cmd.exe";
             startInfo.WorkingDirectory = startDirectory ?? Query.EmbeddedPythonHome();
-            startInfo.Arguments = $"{commandMode} {command}";
+            startInfo.Arguments = $"{commandMode} {command} & exit";
 
             process.StartInfo = startInfo;
             process.Start();


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #19 

<!-- Add short description of what has been fixed -->
While using the `InstallPythonToolkit` method, the command was run asynchronously, but wasn't terminated properly at the end of the task.


### Test files
<!-- Link to test files to validate the proposed changes -->
https://burohappold.sharepoint.com/:f:/s/BHoM/EvsJ6ZHhETJGpHYIhzPkT_4B2sef9ChpZm-zKGhLBlp6qQ?e=pEk1sN
in the `PythonToolkit#19-FixHangingTasks` folder

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- `Compute.Install` now runs synchronously
- `Compute.Install` now returns a boolean of success
- Any `RunCommand` now also `exit` at the end of execution
