### PR TITLE
Separate the Python program for the BHoM from potential existing Python installations

### DIFF
--- a/Python_Engine/Compute/InstallPython.cs
+++ b/Python_Engine/Compute/InstallPython.cs
@@ -51,7 +51,7 @@ namespace BH.Engine.Python
             if (!Directory.Exists(Query.EmbeddedPythonHome()))
                 Directory.CreateDirectory(Query.EmbeddedPythonHome());
 
-            if (!force && Query.IsInstalled()) // python seems installed, so exit
+            if (!force && Query.IsPythonInstalled()) // python seems installed, so exit
                 return success;
 
             // download the python-embedded compressed archive

--- a/Python_Engine/Compute/InstallPythonToolkit.cs
+++ b/Python_Engine/Compute/InstallPythonToolkit.cs
@@ -49,7 +49,7 @@ namespace BH.Engine.Python
             Compute.InstallPython(force);
 
             // Check the installation was successful 
-            if (!Query.IsInstalled())
+            if (!Query.IsPythonInstalled())
             {
                 BH.Engine.Reflection.Compute.RecordError("Coule not install Python");
                 return new Output<bool, List<string>> { Item1 = success, Item2 = installedPackages };

--- a/Python_Engine/Compute/InstallPythonToolkit.cs
+++ b/Python_Engine/Compute/InstallPythonToolkit.cs
@@ -54,6 +54,7 @@ namespace BH.Engine.Python
                 BH.Engine.Reflection.Compute.RecordError("Coule not install Python");
                 return new Output<bool, List<string>> { Item1 = success, Item2 = installedPackages };
             }
+            installedPackages.Add("Python 3.7");
 
             // Install pip
             Console.WriteLine("Installing pip...");
@@ -66,26 +67,25 @@ namespace BH.Engine.Python
                 return new Output<bool, List<string>> { Item1 = success, Item2 = installedPackages };
             }
 
-            // install project jupyter
-            Console.WriteLine("Installing jupyter...");
-            Compute.PipInstall("jupyter");
-            Compute.PipInstall("jupyterlab");
+            List<string> modules = new List<string>() { "jupyter", "jupyterlab", "pythonnet", "matplotlib" };
 
-            // install pythonnet
-            Compute.PipInstall("pythonnet");
+            // installing basic modules
+            foreach(string module in modules)
+            {
+                Console.WriteLine($"Installing {module}");
+                Compute.PipInstall(module);
+                if (Query.IsModuleInstalled(module))
+                    installedPackages.Add(module);
+            }
 
-            //Install matplotlib for graphs
-            Compute.PipInstall("matplotlib");
-            // install pyBHoM
+            // install Python_Toolkit
             string pyBHoMpath = Path.Combine(Query.EmbeddedPythonHome(), "src", "Python_Toolkit");
             Compute.PipInstall($"-e {pyBHoMpath}", force: force);
-
-            installedPackages.Add("Python 3.7");
-            installedPackages.Add("jupyter");
-            installedPackages.Add("jupyterlab");
-            installedPackages.Add("pythonnet");
-            installedPackages.Add("matplotlib");
-            installedPackages.Add("pyBHoM");
+            foreach(string module in new List<string>() { "pyBHoM", "Python_Engine"})
+            {
+                if (Query.IsModuleInstalled(module))
+                    installedPackages.Add(module);
+            }
 
             success = true;
             return new Output<bool, List<string>> { Item1 = success, Item2 = installedPackages };

--- a/Python_Engine/Compute/Invoke.cs
+++ b/Python_Engine/Compute/Invoke.cs
@@ -34,12 +34,6 @@ namespace BH.Engine.Python
 
         public static PyObject Invoke(PyObject module, string method, Dictionary<string, object> args)
         {
-            if(!Query.IsInstalled())
-            {
-                BH.Engine.Reflection.Compute.RecordError("The Python Toolkit has not been successfully installed. Please run the InstallPythonToolkit component to install the necessary dependencies to invoke Python methods within BHoM");
-                return null;
-            }
-
             PyTuple pyargs = Convert.ToPyTuple(new object[]
             {
                 args.FirstOrDefault().Value
@@ -65,12 +59,6 @@ namespace BH.Engine.Python
 
         public static PyObject Invoke(PyObject module, string method, IEnumerable<object> args, Dictionary<string, object> kwargs)
         {
-            if (!Query.IsInstalled())
-            {
-                BH.Engine.Reflection.Compute.RecordError("The Python Toolkit has not been successfully installed. Please run the InstallPythonToolkit component to install the necessary dependencies to invoke Python methods within BHoM");
-                return null;
-            }
-
             PyTuple pyargs = Convert.ToPyTuple(args);
             PyDict pykwargs = Convert.ToPython(kwargs);
 

--- a/Python_Engine/Python_Engine.csproj
+++ b/Python_Engine/Python_Engine.csproj
@@ -37,9 +37,11 @@
     </Reference>
     <Reference Include="Reflection_Engine">
       <HintPath>C:\ProgramData\BHoM\Assemblies\Reflection_Engine.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="Reflection_oM">
       <HintPath>C:\ProgramData\BHoM\Assemblies\Reflection_oM.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/Python_Engine/Query/Import.cs
+++ b/Python_Engine/Query/Import.cs
@@ -21,6 +21,8 @@
  */
 
 using Python.Runtime;
+using System;
+using System.IO;
 
 namespace BH.Engine.Python
 {
@@ -32,13 +34,15 @@ namespace BH.Engine.Python
 
         public static PyObject Import(string moduleName)
         {
+            // check if python is installed
+            if (!Query.IsPythonInstalled())
+                throw new Exception($"Cannot import module {moduleName} because no valid version of Python for the BHoM has been found.\n" +
+                    "Try installing Python and the Python_Toolkit using the Compute.InstallPythonToolkit component.\n" +
+                    "If the installation process fails, pleae consider reporting a bug at " +
+                    "https://github.com/BHoM/MachineLearning_Toolkit/issues/new?labels=type%3Abug&template=00_bug.md");
+            // if python fails to be initialised, it will throw an exception, which can be caught by the TryImport method
             PythonEngine.Initialize();
-            PyObject module = null;
-            using (Py.GIL())
-            {
-                module = Py.Import(moduleName);
-            }
-            return module;
+            return PythonEngine.ImportModule(moduleName);
         }
 
         /***************************************************/
@@ -51,7 +55,7 @@ namespace BH.Engine.Python
             }
             catch (PythonException e)
             {
-                BH.Engine.Reflection.Compute.RecordNote(e.Message);
+                BH.Engine.Reflection.Compute.RecordWarning(e.Message);
                 return null;
             }
         }

--- a/Python_Engine/Query/Import.cs
+++ b/Python_Engine/Query/Import.cs
@@ -40,6 +40,14 @@ namespace BH.Engine.Python
                     "Try installing Python and the Python_Toolkit using the Compute.InstallPythonToolkit component.\n" +
                     "If the installation process fails, pleae consider reporting a bug at " +
                     "https://github.com/BHoM/MachineLearning_Toolkit/issues/new?labels=type%3Abug&template=00_bug.md");
+
+            //// Make sure that the BHoM is loading our bespoke python program
+            string pythonHome = Query.EmbeddedPythonHome();
+            string path = Environment.GetEnvironmentVariable("PATH");
+            Environment.SetEnvironmentVariable("PATH", pythonHome + ";" + path, EnvironmentVariableTarget.Process);
+            Environment.SetEnvironmentVariable("PYTHONHOME", pythonHome, EnvironmentVariableTarget.Process);
+            Environment.SetEnvironmentVariable("PYTHONPATH", Path.Combine(pythonHome, "python.exe"), EnvironmentVariableTarget.Process);
+
             // if python fails to be initialised, it will throw an exception, which can be caught by the TryImport method
             PythonEngine.Initialize();
             return PythonEngine.ImportModule(moduleName);

--- a/Python_Engine/Query/IsInstalled.cs
+++ b/Python_Engine/Query/IsInstalled.cs
@@ -30,7 +30,7 @@ namespace BH.Engine.Python
         /**** Public Methods                            ****/
         /***************************************************/
 
-        public static bool IsInstalled()
+        public static bool IsPythonInstalled()
         {
             return File.Exists(Path.Combine(Query.EmbeddedPythonHome(), "python.exe"));
 
@@ -47,7 +47,7 @@ namespace BH.Engine.Python
 
         public static bool IsModuleInstalled(string module)
         {
-            if (!IsInstalled())
+            if (!IsPythonInstalled())
                 return false;
 
             string packagesDir = Path.Combine(Query.EmbeddedPythonHome(), "Lib", "site-packages");


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->
   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes https://github.com/BHoM/MachineLearning_Toolkit/pull/19

<!-- Add short description of what has been fixed -->
This pr support https://github.com/BHoM/MachineLearning_Toolkit/pull/19 by fixing the path to python.
The issue was that, if you have another python installation on your machine, and the BHoM Python is not installed, the application would crash completely.
We solve by removing the reference to the `PATH` completely, and adding it on the fly.

### Test files
<!-- Link to test files to validate the proposed changes -->
Our usual https://burohappold.sharepoint.com/:f:/s/BHoM/EmYIW2WfjUtPkIYccZ-8V8gBZTOmUfLfgK1gllazCEilcQ?e=dprvsm

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- Rename `Query.IsIntalled` to `Query.IsPythonInstalled`
- Fix `Copy Local`s and set them to `False`
- PythonPath is not registered anymore at installation time and user level environment variable. We now set it to process level at runtime.
- Make sure that the installed modules are actually installed during `InstallPythonToolkit`.

### Additional comments
<!-- As required -->
This pr support https://github.com/BHoM/MachineLearning_Toolkit/pull/19, please review the MachineLearning one using this base.