### PR TITLE
Do not add the BHoM-PythonHome to the PATH Environment variable

### DIFF
--- a/Python_Engine/Compute/InstallPython.cs
+++ b/Python_Engine/Compute/InstallPython.cs
@@ -41,13 +41,6 @@ namespace BH.Engine.Python
         {
             bool success = true;
 
-            // add python to the PATH
-            string home = Query.EmbeddedPythonHome();
-            string path = Environment.GetEnvironmentVariable("PATH", EnvironmentVariableTarget.User);
-            if (!path.Contains(home))
-                Environment.SetEnvironmentVariable("PATH", path + ";" + home, EnvironmentVariableTarget.User);
-
-            // create the python home directory
             if (!Directory.Exists(Query.EmbeddedPythonHome()))
                 Directory.CreateDirectory(Query.EmbeddedPythonHome());
 


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #35
<!-- Add short description of what has been fixed -->
We have been adding `C:\ProgramData\BHoM\python-3.7.3-embed-amd64` to the `PATH`, but this is not required and can potentially lead to conflicts with other python installations.

### Test files
<!-- Link to test files to validate the proposed changes -->
1. Remove `C:\ProgramData\BHoM\python-3.7.3-embed-amd64` from your PATH Environment variable
2. Remove the entire `C:\ProgramData\BHoM\python-3.7.3-embed-amd64` folder
3. Compile the toolkit
4. Open Grasshopper and run `InstallPythonToolkit`
5. Restart Rhinoceros
6. Try to `Import` the `Python_Engine.Compute` module


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->