### PR TITLE
Automatically install python if missing

### DIFF
--- a/Python_Engine/Convert/FromPython.cs
+++ b/Python_Engine/Convert/FromPython.cs
@@ -60,7 +60,6 @@ namespace BH.Engine.Python
             else if (Runtime.PyNumber_Check(handle))
                 return FromPython(new PyFloat(Runtime.PyNumber_Float(handle)));
 
-            throw new Exception($"WHAT THE FUCK IS THIS {obj}");
             return FromPython(obj as dynamic);
         }
 
@@ -145,5 +144,12 @@ namespace BH.Engine.Python
 
         /***************************************************/
 
+        private static object FromPython(this object obj)
+        {
+            Engine.Reflection.Compute.RecordError($"Cannot convert from Python object of type {obj.GetType()}");
+            return null;
+        }
+
+        /***************************************************/
     }
 }

--- a/Python_Engine/Convert/ToPython.cs
+++ b/Python_Engine/Convert/ToPython.cs
@@ -191,7 +191,16 @@ namespace BH.Engine.Python
 
             return new PyTuple(array);
         }
-        
+
         /***************************************************/
+
+        private static PyObject ToPython(this object obj)
+        {
+            Engine.Reflection.Compute.RecordError($"Cannot convert to Python object of type {obj.GetType()}");
+            return null;
+        }
+
+        /***************************************************/
+
     }
 }

--- a/Python_Engine/Python_Engine.csproj
+++ b/Python_Engine/Python_Engine.csproj
@@ -46,6 +46,7 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.IO.Compression.FileSystem" />
+    <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />

--- a/Python_Engine/Query/Import.cs
+++ b/Python_Engine/Query/Import.cs
@@ -22,7 +22,10 @@
 
 using Python.Runtime;
 using System;
+using System.Windows.Forms;
 using System.IO;
+using BH.oM.Reflection;
+using System.Collections.Generic;
 
 namespace BH.Engine.Python
 {
@@ -36,10 +39,26 @@ namespace BH.Engine.Python
         {
             // check if python is installed
             if (!Query.IsPythonInstalled())
-                throw new Exception($"Cannot import module {moduleName} because no valid version of Python for the BHoM has been found.\n" +
-                    "Try installing Python and the Python_Toolkit using the Compute.InstallPythonToolkit component.\n" +
-                    "If the installation process fails, pleae consider reporting a bug at " +
-                    "https://github.com/BHoM/MachineLearning_Toolkit/issues/new?labels=type%3Abug&template=00_bug.md");
+            {
+                string installMessage = $"Cannot import module {moduleName} because no valid version of Python for the BHoM has been found.\n" +
+                "Do you want to install the Python_Toolkit?";
+                DialogResult confirmResult = MessageBox.Show(installMessage, "Python not found", MessageBoxButtons.YesNoCancel);
+
+                if (confirmResult == DialogResult.Yes)
+                {
+                    Output<bool, List<string>> result = Compute.InstallPythonToolkit(true);
+                    Reflection.Compute.RecordWarning("Python has been installed, please restart the UI");
+                }
+                else
+                {
+                    string errorMessage = $"Cannot import module {moduleName}" +
+                                           "Try installing Python and the Python_Toolkit using the Compute.InstallPythonToolkit component.\n" +
+                                           "and the MachineLearning_Toolkit using the Compute.InstallMachineLearning_Toolkit component.\n" +
+                                           "If the installation process fails, pleae consider reporting a bug at " +
+                                           "https://github.com/BHoM/MachineLearning_Toolkit/issues/new?labels=type%3Abug&template=00_bug.md";
+                    throw new Exception(errorMessage);
+                }
+            }
 
             // Make sure that the BHoM is loading our bespoke python program
             Compute.SetPythonHome();

--- a/Python_Engine/Query/Import.cs
+++ b/Python_Engine/Query/Import.cs
@@ -60,27 +60,25 @@ namespace BH.Engine.Python
                 }
             }
 
-            // Make sure that the BHoM is loading our bespoke python program
-            Compute.SetPythonHome();
-
-            // if python fails to be initialised, it will throw an exception, which can be caught by the TryImport method
-            PythonEngine.Initialize();
+            if (!m_Initialised)
+            {
+                // Make sure that the BHoM is loading our bespoke python program
+                Compute.SetPythonHome();
+                // if python fails to be initialised, it will throw an exception, which can be caught by the TryImport method
+                PythonEngine.Initialize();
+                m_Initialised = true;
+            }
             return PythonEngine.ImportModule(moduleName);
         }
 
+
+        /***************************************************/
+        /**** Private Fields                            ****/
         /***************************************************/
 
-        public static PyObject TryImport(string moduleName)
-        {
-            try
-            {
-                return Import(moduleName);
-            }
-            catch (PythonException e)
-            {
-                BH.Engine.Reflection.Compute.RecordWarning(e.Message);
-                return null;
-            }
-        }
+        private static bool m_Initialised = false;
+
+        /***************************************************/
+
     }
 }

--- a/Python_Engine/Query/IsInstalled.cs
+++ b/Python_Engine/Query/IsInstalled.cs
@@ -50,6 +50,8 @@ namespace BH.Engine.Python
             if (!IsPythonInstalled())
                 return false;
 
+            module = module.Split('.')[0];
+
             string packagesDir = Path.Combine(Query.EmbeddedPythonHome(), "Lib", "site-packages");
             string moduleDir = Path.Combine(packagesDir, module);
             bool installed = Directory.Exists(moduleDir) && File.Exists(Path.Combine(moduleDir, "__init__.py"));


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

Depends on: https://github.com/BHoM/MachineLearning_Toolkit/pull/50

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #27 
Closes #37

<!-- Add short description of what has been fixed -->
Ok, so this is definitely improving the UX in my opinion. 
We automatically detect if python is installed and if not, we create a pop up and ask for the installation.


### Test files
<!-- Link to test files to validate the proposed changes -->
1. Remove the `C:\ProgramData\BHoM\Extensions` folder
2. Compile the Python_Toolkit
2. Compile the MachineLearning_Toolkit at this pr https://github.com/BHoM/MachineLearning_Toolkit/pull/50
3. Open this: https://burohappold.sharepoint.com/:u:/r/sites/BHoM/02_Current/12_Scripts/01_Test%20Scripts/MachineLearning_Toolkit/MachineLearning%235-LinearRegression/MachineLearning%235-LinearRegression.gh?csf=1&web=1&e=lt2tVa

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->