### PR TITLE
Fix module check for lazy import

### DIFF
--- a/Python_Engine/Query/IsInstalled.cs
+++ b/Python_Engine/Query/IsInstalled.cs
@@ -55,7 +55,7 @@ namespace BH.Engine.Python
             string packagesDir = Path.Combine(Query.EmbeddedPythonHome(), "Lib", "site-packages");
             string moduleDir = Path.Combine(packagesDir, module);
             bool installed = Directory.Exists(moduleDir) && File.Exists(Path.Combine(moduleDir, "__init__.py"));
-            installed |= File.Exists(Path.Combine(packagesDir, module.Replace("_", "-") + ".egg-link"));
+            installed |= File.Exists(Path.Combine(packagesDir, module.Split('_')[0] + "-Toolkit.egg-link"));
             return installed;
         }
 


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #48 

<!-- Add short description of what has been fixed -->
Necessary adjustment to enable lazy import of modules. Please refer https://github.com/BHoM/MachineLearning_Toolkit/pull/62 for more details.

### Test files
<!-- Link to test files to validate the proposed changes -->


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
 - Adjust module check for Python and MachineLearning toolkits

### Additional comments
<!-- As required -->