### PR TITLE
Ensure PythonEnvironments exists prior to installation of base environment

### DIFF
--- a/Python_Engine/Compute/BasePythonEnvironment.cs
+++ b/Python_Engine/Compute/BasePythonEnvironment.cs
@@ -41,6 +41,10 @@ namespace BH.Engine.Python
             bool reload = true
         )
         {
+            if (!Directory.Exists(Query.DirectoryEnvironments()))
+                // create PythonEnvironments directory if it doesnt already exist
+                Directory.CreateDirectory(Query.DirectoryEnvironments());
+            
             // determine whether the base environment already exists
             string targetExecutable = Path.Combine(Query.DirectoryBaseEnvironment(), "python.exe");
             bool exists = Directory.Exists(Query.DirectoryBaseEnvironment()) && File.Exists(targetExecutable);

--- a/Python_Engine/Compute/BasePythonEnvironment.cs
+++ b/Python_Engine/Compute/BasePythonEnvironment.cs
@@ -42,8 +42,10 @@ namespace BH.Engine.Python
         )
         {
             if (!Directory.Exists(Query.DirectoryEnvironments()))
+            {
                 // create PythonEnvironments directory if it doesnt already exist
                 Directory.CreateDirectory(Query.DirectoryEnvironments());
+            }
             
             // determine whether the base environment already exists
             string targetExecutable = Path.Combine(Query.DirectoryBaseEnvironment(), "python.exe");


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Added a check prior to installing the Base Python environment that creates a `C:\ProgramData\BHoM\Extensions\PythonEnvironments` directory if it doesn't already exist. This _should_ be handled upon BHoM install, but in-case it's missed this is a failsafe.


### Test files
<!-- Link to test files to validate the proposed changes -->
Run BasePythonEnvironment on a machine without a `C:\ProgramData\BHoM\Extensions\PythonEnvironments` directory, and no error should occur.

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->