### PR TITLE
Fixed deadlock on waiting for exit on some processes

### DIFF
--- a/Python_Engine/Compute/BasePythonEnvironment.cs
+++ b/Python_Engine/Compute/BasePythonEnvironment.cs
@@ -82,9 +82,10 @@ namespace BH.Engine.Python
             };
             using (Process p = Process.Start(process.StartInfo))
             {
+                string standardError = p.StandardError.ReadToEnd();
                 p.WaitForExit();
                 if (p.ExitCode != 0)
-                    BH.Engine.Base.Compute.RecordError($"Error installing pip.\n{p.StandardError.ReadToEnd()}");
+                    BH.Engine.Base.Compute.RecordError($"Error installing pip.\n{standardError}");
                 File.Delete(pipInstaller);
             }
 

--- a/Python_Engine/Compute/InstallPackage.cs
+++ b/Python_Engine/Compute/InstallPackage.cs
@@ -64,9 +64,10 @@ namespace BH.Engine.Python
             };
             using (Process p = Process.Start(process.StartInfo))
             {
+                string standardError = p.StandardError.ReadToEnd();
                 p.WaitForExit();
                 if (p.ExitCode != 0)
-                    BH.Engine.Base.Compute.RecordError($"Error installing packages [{packagesString}].\n{p.StandardError.ReadToEnd()}");
+                    BH.Engine.Base.Compute.RecordError($"Error installing packages [{packagesString}].\n{standardError}");
             }
         }
 
@@ -112,9 +113,10 @@ namespace BH.Engine.Python
             };
             using (Process p = Process.Start(process.StartInfo))
             {
+                string standardError = p.StandardError.ReadToEnd();
                 p.WaitForExit();
                 if (p.ExitCode != 0)
-                    BH.Engine.Base.Compute.RecordError($"Error installing packages from {requirements}.\n{p.StandardError.ReadToEnd()}");
+                    BH.Engine.Base.Compute.RecordError($"Error installing packages from {requirements}.\n{standardError}");
             }
         }
 
@@ -155,9 +157,10 @@ namespace BH.Engine.Python
             };
             using (Process p = Process.Start(process.StartInfo))
             {
+                string standardError = p.StandardError.ReadToEnd();
                 p.WaitForExit();
                 if (p.ExitCode != 0)
-                    BH.Engine.Base.Compute.RecordError($"Error installing package from \"{packageDirectory}\".\n{p.StandardError.ReadToEnd()}");
+                    BH.Engine.Base.Compute.RecordError($"Error installing package from \"{packageDirectory}\".\n{standardError}");
             }
         }
 

--- a/Python_Engine/Compute/RequirementsTxt.cs
+++ b/Python_Engine/Compute/RequirementsTxt.cs
@@ -72,10 +72,11 @@ namespace BH.Engine.Python
             using (Process p = Process.Start(process.StartInfo))
             {
                 StreamWriter sr = new StreamWriter(targetPath);
+                sr.Write(p.StandardOutput.ReadToEnd());
+                string standardError = p.StandardError.ReadToEnd();
                 p.WaitForExit();
                 if (p.ExitCode != 0)
-                    BH.Engine.Base.Compute.RecordError($"Error creating requirements.txt from \"{executable}\".\n{p.StandardError.ReadToEnd()}");
-                sr.Write(p.StandardOutput.ReadToEnd());
+                    BH.Engine.Base.Compute.RecordError($"Error creating requirements.txt from \"{executable}\".\n{standardError}");
                 sr.Close();
             }
 

--- a/Python_Engine/Compute/VirtualEnvironment.cs
+++ b/Python_Engine/Compute/VirtualEnvironment.cs
@@ -100,9 +100,10 @@ namespace BH.Engine.Python
             };
             using (Process p = Process.Start(process.StartInfo))
             {
+                string standardError = p.StandardError.ReadToEnd();
                 p.WaitForExit();
                 if (p.ExitCode != 0)
-                    BH.Engine.Base.Compute.RecordError($"Error creating virtual environment.\n{p.StandardError.ReadToEnd()}");
+                    BH.Engine.Base.Compute.RecordError($"Error creating virtual environment.\n{standardError}");
             }
 
             // install ipykernel, pytest and black into new virtualenv
@@ -121,9 +122,10 @@ namespace BH.Engine.Python
             };
             using (Process p = Process.Start(process2.StartInfo))
             {
+                string standardError = p.StandardError.ReadToEnd();
                 p.WaitForExit();
                 if (p.ExitCode != 0)
-                    BH.Engine.Base.Compute.RecordError($"Error registering the \"{name}\" virtual environment.\n{p.StandardError.ReadToEnd()}");
+                    BH.Engine.Base.Compute.RecordError($"Error registering the \"{name}\" virtual environment.\n{standardError}");
             }
             // replace text in a file
 

--- a/Python_Engine/Query/Version.cs
+++ b/Python_Engine/Query/Version.cs
@@ -58,10 +58,14 @@ namespace BH.Engine.Python
                 string versionString;
                 using (Process p = Process.Start(process.StartInfo))
                 {
+                    string standardError = p.StandardError.ReadToEnd();
+                    versionString = p.StandardOutput.ReadToEnd().TrimEnd();
                     p.WaitForExit();
                     if (p.ExitCode != 0)
-                        BH.Engine.Base.Compute.RecordError($"Error getting Python version.\n{p.StandardError.ReadToEnd()}");
-                    versionString = p.StandardOutput.ReadToEnd().TrimEnd();
+                    {
+                        BH.Engine.Base.Compute.RecordError($"Error getting Python version.\n{standardError}");
+                        return PythonVersion.Undefined;
+                    }
                 }
 
                 return (PythonVersion)Enum.Parse(typeof(PythonVersion), "v" + versionString.Replace("Python ", "").Replace(".", "_"));


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #137 

<!-- Add short description of what has been fixed -->
Moved reading standard error and standard output to before waiting for exit on process.
Turns out this was seen before, if you look at `RunCommandStdOut`, there is a comment that says to read stdout and stderr before waiting to exit to avoid deadlocks, but it must have been missed for the other methods. 🤦 

### Test files
<!-- Link to test files to validate the proposed changes -->


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->
not very easy to test all of these, though InstallPackageLocal should be enough to prove that it works (as that is where the error was originally). do not merge unless @albinber has tested that it is fixed.