### PR TITLE
Add python code to nuspec as content files

### DIFF
--- a/.ci/BHoMBot/Nuget/BHoM.Interop.Python.nuspec
+++ b/.ci/BHoMBot/Nuget/BHoM.Interop.Python.nuspec
@@ -21,6 +21,8 @@
     </dependencies>
   </metadata>
   <files>
+    <file src="C:\ProgramData\BHoM\Extensions\PythonCode\Python_Toolkit\src\python_toolkit\bhom\wrapped\**\*.*" exclude="**\__pycache__\*;**\docs\**\*" target="contentFiles\any\any\PythonCode\Python_Toolkit\src\python_toolkit\bhom\wrapped"/>
+    <file src="C:\ProgramData\BHoM\Extensions\PythonCode\Python_Toolkit\src\**\*.*" exclude="**\__pycache__\*;**\docs\**\*" target="contentFiles\any\any\PythonEnvironment\Lib\site-packages" />
     <file src="licence/licence.txt" target="" />
     <file src="images/icon.png" target="" />
     <file src="docs/readme.md" target="" />


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #146 

<!-- Add short description of what has been fixed -->
See the [nuspec file for LadybugTools_Toolkit](https://github.com/BHoM/LadybugTools_Toolkit/blob/develop/.ci/BHoMBot/Nuget/BHoM.Interop.LadybugTools.nuspec) as an example and compare to changes made here.
As python bhom analytics now exists in Python_Toolkit code, this must be included in the nuspec content files as well.
(not to mention future additions to Python_Toolkit python code)

### Test files
<!-- Link to test files to validate the proposed changes -->
Likely will have to merge this then see if the bot produces nugets that contain the python files first

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->