### PR TITLE
Added warning if Python is already installed elsewhere on system

### DIFF
--- a/Python_Engine/Compute/Download.cs
+++ b/Python_Engine/Compute/Download.cs
@@ -134,9 +134,11 @@ namespace BH.Engine.Python
 
             string pythonExePath = Path.Combine(basePath, "python.exe");
 
+            // It is possible for the installer to exit with ExitCode==0 without installing Python in the requested location. This can happen if the same version of Python appears to be installed elsewhere on the system. It can also happen if there was a 'dodgy' uninstall of a previous version. We've been unable to figure out where the installer is actually looking for existing installs. In lieu of a better solution, to fix dodgy uninstalls, run the installer again for the target version of Python (download links within EmbeddableURL.cs) and run a combination of 'repair' and 'uninstall' until it's gone. Installing the py launcher (via 'modify' in the installer) before attempting to uninstall could also help. 
+
             if (!File.Exists(pythonExePath))
             {
-                BH.Engine.Base.Compute.RecordError($"The Python installer appears to have completed successfully, but {pythonExePath} does not exist. This usually means that Python version {version} already exists on your machine, but in a different location. Try uninstalling Python from your system before running this BHoM method again.");
+                BH.Engine.Base.Compute.RecordError($"The Python installer appears to have completed successfully, but \n{pythonExePath} does not exist. \nThis usually means that Python {version} already exists on your machine, but in a different location. \nThis toolkit is therefore unable to run any Python commands right now. \nTry uninstalling Python from your system before running this BHoM method again.");
                 return null;
             }
 

--- a/Python_Engine/Compute/Download.cs
+++ b/Python_Engine/Compute/Download.cs
@@ -134,11 +134,11 @@ namespace BH.Engine.Python
 
             string pythonExePath = Path.Combine(basePath, "python.exe");
 
-            // It is possible for the installer to exit with ExitCode==0 without installing Python in the requested location. This can happen if the same version of Python appears to be installed elsewhere on the system. It can also happen if there was a 'dodgy' uninstall of a previous version. We've been unable to figure out where the installer is actually looking for existing installs. In lieu of a better solution, to fix dodgy uninstalls, run the installer again for the target version of Python (download links within EmbeddableURL.cs) and run a combination of 'repair' and 'uninstall' until it's gone. Installing the py launcher (via 'modify' in the installer) before attempting to uninstall could also help. 
+            // It is possible for the installer to exit with ExitCode==0 without installing Python in the requested location. This can happen if the same version of Python appears to be installed elsewhere on the system. It can also happen if there was a 'dodgy' uninstall of a previous version. We've been unable to figure out where the installer is actually looking for existing installs. To fix dodgy uninstalls, run the installer again for the target version of Python (download links within EmbeddableURL.cs) and run a combination of 'repair' and 'uninstall' until it's gone. Installing the py launcher (via 'modify' in the installer) before attempting to uninstall could also help. 
 
             if (!File.Exists(pythonExePath))
             {
-                BH.Engine.Base.Compute.RecordError($"The Python installer appears to have completed successfully, but \n{pythonExePath} does not exist. \nThis usually means that Python {version} already exists on your machine, but in a different location. \nThis toolkit is therefore unable to run any Python commands right now. \nTry uninstalling Python from your system before running this BHoM method again.");
+                BH.Engine.Base.Compute.RecordError($"The Python installer appears to have completed successfully, but \n{pythonExePath} does not exist. \nThis usually means that Python {version} already exists on your machine, but in a different location. \nThis toolkit is therefore unable to run any Python commands right now. \nTry uninstalling Python {version} from your system before running this BHoM method again.");
                 return null;
             }
 

--- a/Python_Engine/Compute/Download.cs
+++ b/Python_Engine/Compute/Download.cs
@@ -132,7 +132,15 @@ namespace BH.Engine.Python
                 }
             }
 
-            return Path.Combine(basePath, "python.exe");
+            string pythonExePath = Path.Combine(basePath, "python.exe");
+
+            if (!File.Exists(pythonExePath))
+            {
+                BH.Engine.Base.Compute.RecordError($"The Python installer appears to have completed successfully, but {pythonExePath} does not exist. This usually means that Python version {version} already exists on your machine, but in a different location. Try uninstalling Python from your system before running this BHoM method again.");
+                return null;
+            }
+
+            return pythonExePath;
         }
     }
 }

--- a/Python_Engine/Query/Directory.cs
+++ b/Python_Engine/Query/Directory.cs
@@ -1,6 +1,6 @@
 /*
  * This file is part of the Buildings and Habitats object Model (BHoM)
- * Copyright (c) 2015 - 2025, the respective contributors. All rights reserved.
+ * Copyright (c) 2015 - 2024, the respective contributors. All rights reserved.
  *
  * Each contributor holds copyright over their respective contributions.
  * The project versioning (Git) records all such contribution source information.
@@ -67,6 +67,7 @@ namespace BH.Engine.Python
             return dir;
         }
 
+        [PreviousVersion("8.0", "BH.Engine.Python.Query.DirectoryBaseEnvironment()")]
         [Description("The location where the base Python environment exists.")]
         [Input("version", "The python version to get the base environment for.")]
         [Output("path", "The location where the base Python environment exists.")]
@@ -76,7 +77,6 @@ namespace BH.Engine.Python
         }
     }
 }
-
 
 
 


### PR DESCRIPTION
Any given version of Python X.X can only be installed once on a system, and the Python installer checks if its own version already exists before proceeding. If it already exists, the installer will exit without returning a warning or a non-0 exit code. In Python_Toolkit, this causes everything downstream to fail without a helpful warning.

This was found following a dodgy uninstall of Python on my own system, but also would apply if the user has simply installed Python elsewhere on their system already. This PR doesn't address everything in the issue (it turns out the Python installation is a complex beast) but at least the addition of a warning will help the user better diagnose a failed install. 

Closes #156

To test, try running a BHoM Python component (e.g. one of the test scripts) when Python is already installed correctly, when it is not installed at all, and when it is installed in a different target location. 