### PR TITLE
Mask pivots correctly when applied to heatmap

### DIFF
--- a/Python_Engine/Python/src/python_toolkit/plot/heatmap.py
+++ b/Python_Engine/Python/src/python_toolkit/plot/heatmap.py
@@ -57,7 +57,8 @@ def heatmap(
             raise ValueError(
                 f"Length of mask ({len(kwargs['mask'])}) must match length of data ({len(series)})."
             )
-        z = np.ma.masked_array(z, mask=kwargs.pop("mask"))
+        mask_flip = kwargs.pop("mask").to_frame().pivot_table(columns=series.index.date, index=series.index.time)
+        z = np.ma.masked_array(z, mask=mask_flip)
 
     # handle non-standard kwargs
     extend = kwargs.pop("extend", "neither")


### PR DESCRIPTION
Previously, a mask did not render correctly when blocking out parts of a heatmap. This fix applies a pivot to the mask to match the pivot applied to the heatmap data, and should now produce a masked plot correctly. 

Closes #154
