### PR TITLE
Fixed missing import and added tests for base64 image encode/decode

### DIFF
--- a/Python_Engine/Python/src/python_toolkit/plot/heatmap.py
+++ b/Python_Engine/Python/src/python_toolkit/plot/heatmap.py
@@ -53,11 +53,13 @@ def heatmap(
     z = day_time_matrix.values
 
     if "mask" in kwargs:
+        if not (isinstance(kwargs["mask"], list) or isinstance(kwargs["mask"], np.ndarray)):
+            raise TypeError("The type of 'mask' must be a list or numpy array")
         if len(kwargs["mask"]) != len(series):
             raise ValueError(
                 f"Length of mask ({len(kwargs['mask'])}) must match length of data ({len(series)})."
             )
-        mask_flip = kwargs.pop("mask").to_frame().pivot_table(columns=series.index.date, index=series.index.time)
+        mask_flip = pd.Series(kwargs.pop("mask")).to_frame().pivot_table(columns=series.index.date, index=series.index.time)
         z = np.ma.masked_array(z, mask=mask_flip)
 
     # handle non-standard kwargs

--- a/Python_Engine/Python/src/python_toolkit/plot/heatmap.py
+++ b/Python_Engine/Python/src/python_toolkit/plot/heatmap.py
@@ -54,7 +54,7 @@ def heatmap(
 
     if "mask" in kwargs:
         if not isinstance(kwargs["mask"], (list, np.ndarray, pd.Series)):
-            raise TypeError("The type of 'mask' must be a list or numpy array")
+            raise TypeError("The type of 'mask' must be a list, numpy ndarray or pandas Series")
         if len(kwargs["mask"]) != len(series):
             raise ValueError(
                 f"Length of mask ({len(kwargs['mask'])}) must match length of data ({len(series)})."

--- a/Python_Engine/Python/src/python_toolkit/plot/heatmap.py
+++ b/Python_Engine/Python/src/python_toolkit/plot/heatmap.py
@@ -53,7 +53,7 @@ def heatmap(
     z = day_time_matrix.values
 
     if "mask" in kwargs:
-        if not (isinstance(kwargs["mask"], list) or isinstance(kwargs["mask"], np.ndarray) or isinstance(kwargs["mask"], pd.Series)):
+        if not isinstance(kwargs["mask"], (list, np.ndarray, pd.Series)):
             raise TypeError("The type of 'mask' must be a list or numpy array")
         if len(kwargs["mask"]) != len(series):
             raise ValueError(

--- a/Python_Engine/Python/src/python_toolkit/plot/heatmap.py
+++ b/Python_Engine/Python/src/python_toolkit/plot/heatmap.py
@@ -53,7 +53,7 @@ def heatmap(
     z = day_time_matrix.values
 
     if "mask" in kwargs:
-        if not (isinstance(kwargs["mask"], list) or isinstance(kwargs["mask"], np.ndarray)):
+        if not (isinstance(kwargs["mask"], list) or isinstance(kwargs["mask"], np.ndarray) or isinstance(kwargs["mask"], pd.Series)):
             raise TypeError("The type of 'mask' must be a list or numpy array")
         if len(kwargs["mask"]) != len(series):
             raise ValueError(

--- a/Python_Engine/Python/src/python_toolkit/plot/utilities.py
+++ b/Python_Engine/Python/src/python_toolkit/plot/utilities.py
@@ -320,7 +320,7 @@ def base64_to_image(base64_string: str, image_path: Path) -> Path:
         base64_string = base64_string.split(";")[-1]
 
     with open(Path(image_path), "wb") as fp:
-        fp.write(base64.decodebytes(base64_string))
+        fp.write(base64.decodebytes(base64_string.encode('utf-8')))
 
     return image_path
 

--- a/Python_Engine/Python/src/python_toolkit/plot/utilities.py
+++ b/Python_Engine/Python/src/python_toolkit/plot/utilities.py
@@ -2,6 +2,7 @@
 
 import base64
 import colorsys
+import io
 from pathlib import Path
 from typing import Any
 import copy

--- a/Python_Engine/Python/tests/test_plot.py
+++ b/Python_Engine/Python/tests/test_plot.py
@@ -142,11 +142,11 @@ def test_heatmap():
     assert isinstance(heatmap(TIMESERIES_COLLECTION), plt.Axes)
     plt.close("all")
 
-    mask = pd.Series(np.random.random(8760) > 0.5)
+    mask = np.random.random(8760) > 0.5
     assert isinstance(heatmap(TIMESERIES_COLLECTION, mask=mask), plt.Axes)
     plt.close("all")
 
-    mask_bad = pd.Series(np.random.random(10) > 0.5)
+    mask_bad = np.random.random(10) > 0.5
     with pytest.raises(ValueError):
         heatmap(TIMESERIES_COLLECTION, mask=mask_bad)
     plt.close("all")

--- a/Python_Engine/Python/tests/test_plot.py
+++ b/Python_Engine/Python/tests/test_plot.py
@@ -142,11 +142,11 @@ def test_heatmap():
     assert isinstance(heatmap(TIMESERIES_COLLECTION), plt.Axes)
     plt.close("all")
 
-    mask = np.random.random(8760) > 0.5
+    mask = pd.Series(np.random.random(8760) > 0.5)
     assert isinstance(heatmap(TIMESERIES_COLLECTION, mask=mask), plt.Axes)
     plt.close("all")
 
-    mask_bad = np.random.random(10) > 0.5
+    mask_bad = pd.Series(np.random.random(10) > 0.5)
     with pytest.raises(ValueError):
         heatmap(TIMESERIES_COLLECTION, mask=mask_bad)
     plt.close("all")

--- a/Python_Engine/Python/tests/test_plot_utilities.py
+++ b/Python_Engine/Python/tests/test_plot_utilities.py
@@ -1,0 +1,21 @@
+﻿import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+import pytest
+from matplotlib.figure import Figure
+from pathlib import Path
+
+from python_toolkit.plot.utilities import figure_to_base64, image_to_base64, base64_to_image, figure_to_image
+
+def test_figure_round_trip():
+    """very simple test to check that base64 serialisation is working"""
+    fig, ax = plt.subplots(1, 1)
+    base64 = figure_to_base64(fig)
+    assert isinstance(base64, str)
+
+    path = base64_to_image(base64, image_path = Path("tests/assets/temp.png").resolve())
+    assert path.exists()
+    
+    base64_2 = image_to_base64(path)
+    path.unlink() #make sure to clean up after ourselves
+    assert base64 == base64_2


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #165

<!-- Add short description of what has been fixed -->
also fix incorrect type for heatmap mask.

### Test files
<!-- Link to test files to validate the proposed changes -->
run 'run_tests.bat' and ensure all tests pass.

Known issue: sometimes the test fails and provides a tcl error. If this occurs on `test_heatmap` or `test_figure_round_trip`, then ignore this and re-run the test, if it occurs on any other test then it can be ignored.

The tcl error seems to be some sort of weird issue where tkinter can't find itself, even if it does exist - but only when using the pytest module.

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->