### PR TITLE
Fix heatmap error when some values in the input series are null

### DIFF
--- a/Python_Engine/Python/src/python_toolkit/plot/heatmap.py
+++ b/Python_Engine/Python/src/python_toolkit/plot/heatmap.py
@@ -44,7 +44,7 @@ def heatmap(
     day_time_matrix = (
         series.dropna()
         .to_frame()
-        .pivot_table(columns=series.index.date, index=series.index.time)
+        .pivot_table(columns=series.dropna().index.date, index=series.dropna().index.time)
     )
     x = mdates.date2num(day_time_matrix.columns.get_level_values(1))
     y = mdates.date2num(


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #167

<!-- Add short description of what has been fixed -->
see the linked issue

### Test files
<!-- Link to test files to validate the proposed changes -->
Run the heatmap with a series that has some null values in the middle

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->