### PR TITLE
Use agg when testing plot methods

### DIFF
--- a/Python_Engine/Python/tests/__init__.py
+++ b/Python_Engine/Python/tests/__init__.py
@@ -1,5 +1,7 @@
 ﻿from pathlib import Path
 import pandas as pd
+import matplotlib as mpl
+
 
 # identifier for all downstream processes
 BASE_IDENTIFIER = "PythonBHoM_pytest"
@@ -10,3 +12,6 @@ def get_timeseries():
     return pd.Series(df["Value"], index=df.index)
 
 TIMESERIES_COLLECTION = get_timeseries()
+
+#use 'agg' for testing plot methods, as tkinter occasionally throws strange errors (missing component/library when component isn't missing) when the default backend is used only when using pytest
+mpl.use("agg")


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #169 

<!-- Add short description of what has been fixed -->
As in title, doing `mpl.use("agg")` in the test folders' `__init__.py` file.
Basically what was happening was tkinter is failing seemingly randomly when using pytest citing that one of its libraries/modules is missing even when it isn't. So switch to "agg" backend as we're not testing whether tkinter works, we're testing that the plot can be created.

### Test files
<!-- Link to test files to validate the proposed changes -->
run the unit tests, and see that there are no failing plot tests.
If there are any failing tests for other reasons, then please comment to be tackled in a separate issue

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->