### PR TITLE
Log file paths converted to string to comply with logging parameter types

### DIFF
--- a/Python_Engine/Python/src/python_toolkit/bhom/analytics.py
+++ b/Python_Engine/Python/src/python_toolkit/bhom/analytics.py
@@ -83,7 +83,7 @@ def bhom_analytics() -> Callable:
                 exec_metadata["Errors"].extend(sys.exc_info())
                 raise exc
             finally:
-                log_file = BHOM_LOG_FOLDER / f"{function.__module__.split('.')[0]}_{datetime.now().strftime('%Y%m%d')}.log"
+                log_file = str(BHOM_LOG_FOLDER / f"{function.__module__.split('.')[0]}_{datetime.now().strftime('%Y%m%d')}.log")
 
                 if ANALYTICS_LOGGER.handlers[0].baseFilename != log_file:
                     ANALYTICS_LOGGER.handlers[0].close()

--- a/Python_Engine/Python/src/python_toolkit/bhom/analytics.py
+++ b/Python_Engine/Python/src/python_toolkit/bhom/analytics.py
@@ -85,7 +85,7 @@ def bhom_analytics() -> Callable:
             finally:
                 log_file = BHOM_LOG_FOLDER / f"{function.__module__.split('.')[0]}_{datetime.now().strftime('%Y%m%d')}.log"
 
-                if ANALYTICS_LOGGER.handlers[0].baseFilename != log_file:
+                if ANALYTICS_LOGGER.handlers[0].baseFilename != str(log_file):
                     ANALYTICS_LOGGER.handlers[0].close()
                     ANALYTICS_LOGGER.handlers[0].baseFilename = str(log_file)
 

--- a/Python_Engine/Python/src/python_toolkit/bhom/analytics.py
+++ b/Python_Engine/Python/src/python_toolkit/bhom/analytics.py
@@ -83,11 +83,11 @@ def bhom_analytics() -> Callable:
                 exec_metadata["Errors"].extend(sys.exc_info())
                 raise exc
             finally:
-                log_file = str(BHOM_LOG_FOLDER / f"{function.__module__.split('.')[0]}_{datetime.now().strftime('%Y%m%d')}.log")
+                log_file = BHOM_LOG_FOLDER / f"{function.__module__.split('.')[0]}_{datetime.now().strftime('%Y%m%d')}.log"
 
                 if ANALYTICS_LOGGER.handlers[0].baseFilename != log_file:
                     ANALYTICS_LOGGER.handlers[0].close()
-                    ANALYTICS_LOGGER.handlers[0].baseFilename = log_file
+                    ANALYTICS_LOGGER.handlers[0].baseFilename = str(log_file)
 
                 ANALYTICS_LOGGER.info(
                     json.dumps(exec_metadata, default=str, indent=None)

--- a/Python_Engine/Python/src/python_toolkit/bhom/logging/file.py
+++ b/Python_Engine/Python/src/python_toolkit/bhom/logging/file.py
@@ -12,7 +12,7 @@ from .. import TOOLKIT_NAME, BHOM_LOG_FOLDER
 
 formatter = logging.Formatter("%(message)s")
 handler = RotatingFileHandler(
-    BHOM_LOG_FOLDER / f"{TOOLKIT_NAME}_{datetime.now().strftime('%Y%m%d')}.log",
+    str(BHOM_LOG_FOLDER / f"{TOOLKIT_NAME}_{datetime.now().strftime('%Y%m%d')}.log"),
     mode="a",
     maxBytes=25 * 1024 * 1024,  # 25mb max before file overwritten
     backupCount=1,


### PR DESCRIPTION


   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #171

<!-- Add short description of what has been fixed -->


### Test files

Manually edit today's python_toolkit log file to be >25Mb. Then run a Python action that appends to the log file (I created an ExternalComfort object in LBT_TK). The action should run successfully. The log file should be renamed to `f<filename>.log.1` and a new log file with `<filename.>log` should be created in the same log folder. 

The log folder is here: C:\ProgramData\BHoM\Logs
