### PR TITLE
Fixed incorrect kernel directory location check

### DIFF
--- a/Python_Engine/Query/Directory.cs
+++ b/Python_Engine/Query/Directory.cs
@@ -41,7 +41,7 @@ namespace BH.Engine.Python
         public static string DirectoryKernels()
         {
             
-            string dir = Path.Combine(System.Environment.GetFolderPath(System.Environment.SpecialFolder.CommonApplicationData), "jupyter", "kernels");
+            string dir = Path.Combine(System.Environment.GetFolderPath(System.Environment.SpecialFolder.ApplicationData), "jupyter", "kernels");
             if (!Directory.Exists(dir))
                 Directory.CreateDirectory(dir);
             return dir;


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #184 

<!-- Add short description of what has been fixed -->
see linked issue

### Test files
<!-- Link to test files to validate the proposed changes -->
try running `Query.VirtualEnvironmentExists` with `LadybugTools_Toolkit` while that python env is installed, and ensure that it returns true.

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->
oops, the branch name references the wrong issue :D