### PR TITLE
Fix incorrect setup for install of python environments.

### DIFF
--- a/Python_Engine/Compute/Remove.cs
+++ b/Python_Engine/Compute/Remove.cs
@@ -37,7 +37,7 @@ namespace BH.Engine.Python
         [Input("kernelName", "The name of the kernel to remove.")]
         public static void RemoveKernel(string kernelName)
         {
-            string kernelPath = Path.Combine(Query.DirectoryKernels(), kernelName);
+            string kernelPath = Path.Combine(Query.DirectoryKernels(), kernelName.ToLower());
             if (Directory.Exists(kernelPath))
                 Directory.Delete(kernelPath, true);
         }

--- a/Python_Engine/Compute/VirtualEnvironment.cs
+++ b/Python_Engine/Compute/VirtualEnvironment.cs
@@ -116,7 +116,7 @@ namespace BH.Engine.Python
                 }
             };
 
-            process.StartInfo.Environment["PYTHONHOME"] = "";
+            process2.StartInfo.Environment["PYTHONHOME"] = "";
 
             using (Process p = Process.Start(process2.StartInfo))
             {

--- a/Python_Engine/Query/VirtualEnvironment.cs
+++ b/Python_Engine/Query/VirtualEnvironment.cs
@@ -60,7 +60,7 @@ namespace BH.Engine.Python
         [Output("kernelDirectory", "The path to the kernel directory.")]
         public static string VirtualEnvironmentKernel(string envName)
         {
-            return Path.Combine(Query.DirectoryKernels(), envName);
+            return Path.Combine(Query.DirectoryKernels(), envName.ToLower());
         }
 
         [Description("Get the path to the named BHoM Python virtual environment executable.")]


### PR DESCRIPTION
as jupyter kernel folders are always stored lowercase and for some file systems the query method does not work where it does in others.

<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #211 

<!-- Add short description of what has been fixed -->
Also fixed kernels not being retrieved as lower.

### Test files
<!-- Link to test files to validate the proposed changes -->
Create a script with a rhino 8 python component, then run a virtual environment installer

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->