### PR TITLE
Fix typos in log record summarisation, and add __Time__ field.

### DIFF
--- a/Python_Engine/Python/src/python_toolkit/bhom/analytics.py
+++ b/Python_Engine/Python/src/python_toolkit/bhom/analytics.py
@@ -71,7 +71,7 @@ def summarise_usage_logs(usage_log_entries:List[UsageLogEntry]) -> List[Dict]:
 
     usage_log_entries.sort(key=lambda x: x.ProjectID)
 
-    short_bhom_version = BHOM_VERSION.rsplit(".", 2)[0]
+    short_bhom_version = ".".join(BHOM_VERSION.split(".", 2)[0:1])
 
     for file_id, filegroup in groupby(usage_log_entries, lambda x: x.FileId):
         filegroup = list(filegroup)

--- a/Python_Engine/Python/src/python_toolkit/bhom/analytics.py
+++ b/Python_Engine/Python/src/python_toolkit/bhom/analytics.py
@@ -89,15 +89,16 @@ def summarise_usage_logs(usage_log_entries:List[UsageLogEntry]) -> List[Dict]:
                 "CallerName": first_entry.CallerName,
                 "SelectedItem": first_entry.SelectedItem,
                 "Computer": socket.gethostname(),
-                "UserName": os.environ.get("USERNAME"),
+                "Username": os.environ.get("USERNAME"),
                 "BHoMVersion": BHOM_VERSION,
                 "FileId": file_id,
                 "FileName": filename,
                 "ProjectID": project_id,
                 "NbCallingComponents": len(set([a.ComponentId for a in methodgroup])),
-                "TotalNbCals": len(methodgroup),
+                "TotalNbCalls": len(methodgroup),
                 "Errors": list(itertools.chain.from_iterable([x.Errors for x in methodgroup])),
-                "_t": "BH.oM.BHoMAnalytics.UsageEntry"
+                "_t": "BH.oM.BHoMAnalytics.UsageEntry",
+                "__Time__": datetime.now()
             })
 
     return db_entries

--- a/Python_Engine/Python/src/python_toolkit/bhom/analytics.py
+++ b/Python_Engine/Python/src/python_toolkit/bhom/analytics.py
@@ -71,6 +71,8 @@ def summarise_usage_logs(usage_log_entries:List[UsageLogEntry]) -> List[Dict]:
 
     usage_log_entries.sort(key=lambda x: x.ProjectID)
 
+    short_bhom_version = BHOM_VERSION.rsplit(".", 2)[0]
+
     for file_id, filegroup in groupby(usage_log_entries, lambda x: x.FileId):
         filegroup = list(filegroup)
         project_id = filegroup[0].ProjectID
@@ -90,7 +92,7 @@ def summarise_usage_logs(usage_log_entries:List[UsageLogEntry]) -> List[Dict]:
                 "SelectedItem": first_entry.SelectedItem,
                 "Computer": socket.gethostname(),
                 "Username": os.environ.get("USERNAME"),
-                "BHoMVersion": BHOM_VERSION,
+                "BHoMVersion": short_bhom_version,
                 "FileId": file_id,
                 "FileName": filename,
                 "ProjectID": project_id,
@@ -98,7 +100,8 @@ def summarise_usage_logs(usage_log_entries:List[UsageLogEntry]) -> List[Dict]:
                 "TotalNbCalls": len(methodgroup),
                 "Errors": list(itertools.chain.from_iterable([x.Errors for x in methodgroup])),
                 "_t": "BH.oM.BHoMAnalytics.UsageEntry",
-                "__Time__": datetime.now()
+                "__Time__": datetime.now(),
+                "_bhomVersion": short_bhom_version
             })
 
     return db_entries

--- a/Python_Engine/Python/src/python_toolkit/bhom/analytics.py
+++ b/Python_Engine/Python/src/python_toolkit/bhom/analytics.py
@@ -71,7 +71,7 @@ def summarise_usage_logs(usage_log_entries:List[UsageLogEntry]) -> List[Dict]:
 
     usage_log_entries.sort(key=lambda x: x.ProjectID)
 
-    short_bhom_version = ".".join(BHOM_VERSION.split(".", 2)[0:1])
+    short_bhom_version = ".".join(BHOM_VERSION.split(".", 2)[0:2])
 
     for file_id, filegroup in groupby(usage_log_entries, lambda x: x.FileId):
         filegroup = list(filegroup)


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #224 

<!-- Add short description of what has been fixed -->
see linked issue

### Test files
<!-- Link to test files to validate the proposed changes -->


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
* Fix typos in logging

### Additional comments
<!-- As required -->
Tagging @sakanni and @adecler so you can keep track of these changes. For posterity, before this change:
* Use `__Time__` fallback to `EndTime`
* Use `Username` fallback to `UserName`
* Use `TotalNbCalls` fallback to `TotalNbCals`

This should only need to be done to UI:Python logs but it may summarise non-python logs if they are in the log folder and haven't already been summarised.