### PR TITLE
Add ability to specify median and mean lines for diurnal plots

### DIFF
--- a/Python_Engine/Python/src/python_toolkit/plot/diurnal.py
+++ b/Python_Engine/Python/src/python_toolkit/plot/diurnal.py
@@ -134,14 +134,14 @@ def diurnal(
         # Get values to plot
         minima = group.min()
         lower = group.quantile(quantile_range[0])
-        median = group.median()
-        mean = group.mean()
+        median_series = group.median()
+        mean_series = group.mean()
         upper = group.quantile(quantile_range[1])
         maxima = group.max()
 
         # create df for re-indexing
         df = pd.concat(
-            [minima, lower, median, mean, upper, maxima],
+            [minima, lower, median_series, mean_series, upper, maxima],
             axis=1,
             keys=["minima", "lower", "median", "mean", "upper", "maxima"],
         ).reindex(target_idx)

--- a/Python_Engine/Python/src/python_toolkit/plot/diurnal.py
+++ b/Python_Engine/Python/src/python_toolkit/plot/diurnal.py
@@ -20,6 +20,8 @@ def diurnal(
     series: pd.Series,
     ax: plt.Axes = None,
     period: str = "daily",
+    median: bool = True,
+    mean: bool = True,
     **kwargs,
 ) -> plt.Axes:
     """Plot a profile aggregated across days in the specified timeframe.
@@ -31,6 +33,10 @@ def diurnal(
             A matplotlib Axes object. Defaults to None.
         period (str, optional):
             The period to aggregate over. Must be one of "dailyy", "weekly", or "monthly". Defaults to "daily".
+        median (bool, optional):
+            Whether to plot the median line. Default `True`.
+        mean (bool, optional):
+            Whether to plot the mean line. Default `True`.
         **kwargs (Dict[str, Any], optional):
             Additional keyword arguments to pass to the matplotlib plotting function.
             legend (bool, optional):
@@ -42,7 +48,6 @@ def diurnal(
         plt.Axes:
             A matplotlib Axes object.
     """
-
 
     if not isinstance(series.index, pd.DatetimeIndex):
         raise ValueError("Series passed is not datetime indexed.")
@@ -183,24 +188,26 @@ def diurnal(
                 label="_nolegend_",
             )
             # mean/median
-            ax.plot(
-                range(len(df) + 1)[i : i + 25],
-                (df["mean"].tolist() + [df["mean"].values[0]])[i : i + 24]
-                + [(df["mean"].tolist() + [df["mean"].values[0]])[i : i + 24][0]],
-                c=color,
-                ls="-",
-                lw=1,
-                label="Average" if n == 0 else "_nolegend_",
-            )
-            ax.plot(
-                range(len(df) + 1)[i : i + 25],
-                (df["median"].tolist() + [df["median"].values[0]])[i : i + 24]
-                + [(df["median"].tolist() + [df["median"].values[0]])[i : i + 24][0]],
-                c=color,
-                ls="--",
-                lw=1,
-                label="Median" if n == 0 else "_nolegend_",
-            )
+            if mean:
+                ax.plot(
+                    range(len(df) + 1)[i : i + 25],
+                    (df["mean"].tolist() + [df["mean"].values[0]])[i : i + 24]
+                    + [(df["mean"].tolist() + [df["mean"].values[0]])[i : i + 24][0]],
+                    c=color,
+                    ls="-",
+                    lw=1,
+                    label="Average" if n == 0 else "_nolegend_",
+                )
+            if median:
+                ax.plot(
+                    range(len(df) + 1)[i : i + 25],
+                    (df["median"].tolist() + [df["median"].values[0]])[i : i + 24]
+                    + [(df["median"].tolist() + [df["median"].values[0]])[i : i + 24][0]],
+                    c=color,
+                    ls="--",
+                    lw=1,
+                    label="Median" if n == 0 else "_nolegend_",
+                )
 
         # format axes
         ax.set_xlim(0, len(df))

--- a/Python_Engine/Python/src/python_toolkit/plot/diurnal.py
+++ b/Python_Engine/Python/src/python_toolkit/plot/diurnal.py
@@ -2,6 +2,7 @@
 
 import calendar
 import textwrap
+from typing import Tuple
 
 import matplotlib.collections as mcollections
 import matplotlib.lines as mlines
@@ -20,6 +21,7 @@ def diurnal(
     series: pd.Series,
     ax: plt.Axes = None,
     period: str = "daily",
+    quantile_range: Tuple[float, float] = (0.05, 0.95),
     median: bool = True,
     mean: bool = True,
     **kwargs,
@@ -33,6 +35,8 @@ def diurnal(
             A matplotlib Axes object. Defaults to None.
         period (str, optional):
             The period to aggregate over. Must be one of "dailyy", "weekly", or "monthly". Defaults to "daily".
+        quantile_range (Tuple[float, float]):
+            The quantile range to display in a lighter (30% alpha) colour on the plot. Defaults to (0.05, 0.95).
         median (bool, optional):
             Whether to plot the median line. Default `True`.
         mean (bool, optional):
@@ -66,7 +70,6 @@ def diurnal(
             raise ValueError("minmax_range must be increasing.")
         minmax_alpha = kwargs.pop("minmax_alpha", 0.1)
 
-        quantile_range = kwargs.pop("quantile_range", [0.05, 0.95])
         if quantile_range[0] > quantile_range[1]:
             raise ValueError("quantile_range must be increasing.")
         if quantile_range[0] < minmax_range[0] or quantile_range[1] > minmax_range[1]:


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #230

<!-- Add short description of what has been fixed -->
see linked issue
Added ability to remove the mean or median line.

Also added explicit quantile_range argument so it is clearer that that is possible from the method signature

### Test files
<!-- Link to test files to validate the proposed changes -->


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
* Added ability to remove the mean and median line from diurnal plots.
* Added explicit argument for quantile_range for diurnal plots.

### Additional comments
<!-- As required -->